### PR TITLE
Remove deprecated setAccessible() calls

### DIFF
--- a/tests/TestCase/Command/ImageVariantGenerateCommandTest.php
+++ b/tests/TestCase/Command/ImageVariantGenerateCommandTest.php
@@ -101,7 +101,6 @@ class ImageVariantGenerateCommandTest extends TestCase
         // Set the table on the command via reflection since it's protected
         $reflection = new ReflectionClass($command);
         $property = $reflection->getProperty('Table');
-        $property->setAccessible(true);
         $property->setValue($command, $table);
 
         $entity = $table->get(1);
@@ -122,7 +121,6 @@ class ImageVariantGenerateCommandTest extends TestCase
         // Set the table on the command via reflection since it's protected
         $reflection = new ReflectionClass($command);
         $property = $reflection->getProperty('Table');
-        $property->setAccessible(true);
         $property->setValue($command, $table);
 
         $file = File::create(


### PR DESCRIPTION
## Summary
- Remove deprecated `ReflectionProperty::setAccessible()` calls in tests
- Since PHP 8.1, all properties are accessible via reflection, making this call unnecessary
- The method is deprecated in PHP 8.5