### PR TITLE
Fix "Cannot use bool as array" error in ImageValidationTrait

### DIFF
--- a/docs/Documentation/Validation.md
+++ b/docs/Documentation/Validation.md
@@ -30,36 +30,71 @@ class ImageValidator implements UploadValidatorInterface
         $validator->add('file', 'fileUnderPhpSizeLimit', [
             'rule' => 'isUnderPhpSizeLimit',
             'message' => 'This file is too large',
-            'provider' => 'upload'
+            'provider' => 'upload',
         ]);
+
+        // Validate that the file is actually an image before checking dimensions
+        $validator->add('file', 'fileIsValidImage', [
+            'rule' => 'isValidImage',
+            'message' => 'File must be a valid image (JPEG, PNG, GIF, or WebP)',
+            'provider' => 'upload',
+            'on' => function($context) {
+                $file = $context['data']['file'] ?? null;
+                return $file && $file->getError() == UPLOAD_ERR_OK;
+            },
+        ]);
+
         $validator->add('file', 'fileAboveMinHeight', [
             'rule' => ['isAboveMinHeight', 50],
             'message' => 'This image should at least be 50px high',
-            'provider' => 'upload'
+            'provider' => 'upload',
+            'on' => function($context) {
+                $file = $context['data']['file'] ?? null;
+                return $file && $file->getError() == UPLOAD_ERR_OK;
+            },
         ]);
         $validator->add('file', 'fileAboveMinWidth', [
             'rule' => ['isAboveMinWidth', 50],
             'message' => 'This image should at least be 50px wide',
-            'provider' => 'upload'
-        ]);
-
-        $validator->add('file', 'customName', [
-            'rule' => 'nameOfTheRule',
-            'message' => 'yourErrorMessage',
             'provider' => 'upload',
             'on' => function($context) {
-                return !empty($context['data']['file']);
-            }
+                $file = $context['data']['file'] ?? null;
+                return $file && $file->getError() == UPLOAD_ERR_OK;
+            },
         ]);
     }
-
-    /**
-     * @param mixed $data
-     *
-     * @return false
-     */
-    public static function isUnderPhpSizeLimit($data): bool
-    {
-        ...
-    }
 }
+```
+
+## Available Image Validation Rules
+
+The `ImageValidationTrait` provides the following validation methods:
+
+### isValidImage
+
+Validates that the uploaded file is a valid image. Use this before dimension checks to provide clear error messages when non-image files are uploaded.
+
+```php
+// Default: allows JPEG, PNG, GIF, WebP
+$validator->add('file', 'fileIsValidImage', [
+    'rule' => 'isValidImage',
+    'message' => 'File must be a valid image',
+    'provider' => 'upload',
+]);
+
+// Custom allowed types
+$validator->add('file', 'fileIsValidImage', [
+    'rule' => ['isValidImage', [IMAGETYPE_JPEG, IMAGETYPE_PNG]],
+    'message' => 'File must be a JPEG or PNG image',
+    'provider' => 'upload',
+]);
+```
+
+### Dimension Validators
+
+- `isAboveMinWidth($check, int $width)` - Check minimum width
+- `isBelowMaxWidth($check, int $width)` - Check maximum width
+- `isAboveMinHeight($check, int $height)` - Check minimum height
+- `isBelowMaxHeight($check, int $height)` - Check maximum height
+
+All dimension validators safely handle non-image files by returning `false` instead of throwing an error.

--- a/src/Model/Validation/ImageValidationTrait.php
+++ b/src/Model/Validation/ImageValidationTrait.php
@@ -25,9 +25,12 @@ trait ImageValidationTrait
             }
             $file = $check['tmp_name'];
         }
-        [$imgWidth] = getimagesize($file);
+        $imageSize = getimagesize($file);
+        if ($imageSize === false) {
+            return false;
+        }
 
-        return $width > 0 && $imgWidth >= $width;
+        return $width > 0 && $imageSize[0] >= $width;
     }
 
     /**
@@ -50,9 +53,12 @@ trait ImageValidationTrait
 
             $file = $check['tmp_name'];
         }
-        [$imgWidth] = getimagesize($file);
+        $imageSize = getimagesize($file);
+        if ($imageSize === false) {
+            return false;
+        }
 
-        return $width > 0 && $imgWidth <= $width;
+        return $width > 0 && $imageSize[0] <= $width;
     }
 
     /**
@@ -74,9 +80,12 @@ trait ImageValidationTrait
             }
             $file = $check['tmp_name'];
         }
-        [, $imgHeight] = getimagesize($file);
+        $imageSize = getimagesize($file);
+        if ($imageSize === false) {
+            return false;
+        }
 
-        return $height > 0 && $imgHeight >= $height;
+        return $height > 0 && $imageSize[1] >= $height;
     }
 
     /**
@@ -98,8 +107,11 @@ trait ImageValidationTrait
             }
             $file = $check['tmp_name'];
         }
-        [, $imgHeight] = getimagesize($file);
+        $imageSize = getimagesize($file);
+        if ($imageSize === false) {
+            return false;
+        }
 
-        return $height > 0 && $imgHeight <= $height;
+        return $height > 0 && $imageSize[1] <= $height;
     }
 }

--- a/src/Model/Validation/ImageValidationTrait.php
+++ b/src/Model/Validation/ImageValidationTrait.php
@@ -7,6 +7,40 @@ use Psr\Http\Message\UploadedFileInterface;
 trait ImageValidationTrait
 {
     /**
+     * Check if the uploaded file is a valid image.
+     *
+     * Use this validation before dimension checks to provide a clear error
+     * message when non-image files are uploaded.
+     *
+     * @param \Psr\Http\Message\UploadedFileInterface|array $check Value to check
+     * @param array<int> $allowedTypes Allowed image types (IMAGETYPE_* constants). Defaults to JPEG, PNG, GIF, WebP.
+     *
+     * @return bool Success
+     */
+    public static function isValidImage($check, array $allowedTypes = []): bool
+    {
+        if ($check instanceof UploadedFileInterface) {
+            $file = $check->getStream()->getMetadata('uri');
+        } else {
+            if (!isset($check['tmp_name']) || !strlen($check['tmp_name'])) {
+                return false;
+            }
+            $file = $check['tmp_name'];
+        }
+
+        $imageInfo = @getimagesize($file);
+        if ($imageInfo === false) {
+            return false;
+        }
+
+        if (!$allowedTypes) {
+            $allowedTypes = [IMAGETYPE_JPEG, IMAGETYPE_PNG, IMAGETYPE_GIF, IMAGETYPE_WEBP];
+        }
+
+        return in_array($imageInfo[2], $allowedTypes, true);
+    }
+
+    /**
      * Check that the file is above the minimum width requirement
      *
      * @param \Psr\Http\Message\UploadedFileInterface|array $check Value to check

--- a/tests/TestCase/Model/Validation/ImageValidationTraitTest.php
+++ b/tests/TestCase/Model/Validation/ImageValidationTraitTest.php
@@ -1,0 +1,239 @@
+<?php declare(strict_types=1);
+
+namespace FileStorage\Test\TestCase\Model\Validation;
+
+use Cake\Core\Plugin;
+use Cake\TestSuite\TestCase;
+use FileStorage\Model\Validation\ImageValidationTrait;
+use Laminas\Diactoros\UploadedFile;
+
+class ImageValidationTraitTest extends TestCase
+{
+    use ImageValidationTrait;
+
+    /**
+     * Path to the file fixtures.
+     *
+     * @var string
+     */
+    protected string $fileFixtures;
+
+    /**
+     * @return void
+     */
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->fileFixtures = Plugin::path('FileStorage') . 'tests' . DS . 'Fixture' . DS . 'File' . DS;
+    }
+
+    /**
+     * @return void
+     */
+    public function testIsValidImageWithValidJpeg(): void
+    {
+        $file = new UploadedFile(
+            $this->fileFixtures . 'titus.jpg',
+            filesize($this->fileFixtures . 'titus.jpg'),
+            UPLOAD_ERR_OK,
+            'titus.jpg',
+            'image/jpeg',
+        );
+
+        $this->assertTrue(static::isValidImage($file));
+    }
+
+    /**
+     * @return void
+     */
+    public function testIsValidImageWithValidPng(): void
+    {
+        $file = new UploadedFile(
+            $this->fileFixtures . 'cake.icon.png',
+            filesize($this->fileFixtures . 'cake.icon.png'),
+            UPLOAD_ERR_OK,
+            'cake.icon.png',
+            'image/png',
+        );
+
+        $this->assertTrue(static::isValidImage($file));
+    }
+
+    /**
+     * @return void
+     */
+    public function testIsValidImageWithTextFile(): void
+    {
+        // Create a temporary text file
+        $tmpFile = TMP . 'test-text-file.txt';
+        file_put_contents($tmpFile, 'This is not an image');
+
+        $file = new UploadedFile(
+            $tmpFile,
+            filesize($tmpFile),
+            UPLOAD_ERR_OK,
+            'test.txt',
+            'text/plain',
+        );
+
+        $this->assertFalse(static::isValidImage($file));
+
+        unlink($tmpFile);
+    }
+
+    /**
+     * @return void
+     */
+    public function testIsValidImageWithCustomAllowedTypes(): void
+    {
+        $file = new UploadedFile(
+            $this->fileFixtures . 'cake.icon.png',
+            filesize($this->fileFixtures . 'cake.icon.png'),
+            UPLOAD_ERR_OK,
+            'cake.icon.png',
+            'image/png',
+        );
+
+        // PNG should pass when PNG is allowed
+        $this->assertTrue(static::isValidImage($file, [IMAGETYPE_PNG]));
+
+        // PNG should fail when only JPEG is allowed
+        $this->assertFalse(static::isValidImage($file, [IMAGETYPE_JPEG]));
+    }
+
+    /**
+     * @return void
+     */
+    public function testIsValidImageWithArrayFormat(): void
+    {
+        $check = [
+            'tmp_name' => $this->fileFixtures . 'titus.jpg',
+            'name' => 'titus.jpg',
+            'type' => 'image/jpeg',
+            'size' => filesize($this->fileFixtures . 'titus.jpg'),
+            'error' => UPLOAD_ERR_OK,
+        ];
+
+        $this->assertTrue(static::isValidImage($check));
+    }
+
+    /**
+     * @return void
+     */
+    public function testIsValidImageWithMissingTmpName(): void
+    {
+        $check = [
+            'name' => 'test.jpg',
+        ];
+
+        $this->assertFalse(static::isValidImage($check));
+    }
+
+    /**
+     * @return void
+     */
+    public function testIsAboveMinWidthWithNonImageFile(): void
+    {
+        // Create a temporary text file
+        $tmpFile = TMP . 'test-not-image.txt';
+        file_put_contents($tmpFile, 'This is not an image');
+
+        $file = new UploadedFile(
+            $tmpFile,
+            filesize($tmpFile),
+            UPLOAD_ERR_OK,
+            'test.txt',
+            'text/plain',
+        );
+
+        // Should return false instead of throwing an error
+        $this->assertFalse(static::isAboveMinWidth($file, 50));
+
+        unlink($tmpFile);
+    }
+
+    /**
+     * @return void
+     */
+    public function testIsBelowMaxWidthWithNonImageFile(): void
+    {
+        $tmpFile = TMP . 'test-not-image.txt';
+        file_put_contents($tmpFile, 'This is not an image');
+
+        $file = new UploadedFile(
+            $tmpFile,
+            filesize($tmpFile),
+            UPLOAD_ERR_OK,
+            'test.txt',
+            'text/plain',
+        );
+
+        $this->assertFalse(static::isBelowMaxWidth($file, 400));
+
+        unlink($tmpFile);
+    }
+
+    /**
+     * @return void
+     */
+    public function testIsAboveMinHeightWithNonImageFile(): void
+    {
+        $tmpFile = TMP . 'test-not-image.txt';
+        file_put_contents($tmpFile, 'This is not an image');
+
+        $file = new UploadedFile(
+            $tmpFile,
+            filesize($tmpFile),
+            UPLOAD_ERR_OK,
+            'test.txt',
+            'text/plain',
+        );
+
+        $this->assertFalse(static::isAboveMinHeight($file, 50));
+
+        unlink($tmpFile);
+    }
+
+    /**
+     * @return void
+     */
+    public function testIsBelowMaxHeightWithNonImageFile(): void
+    {
+        $tmpFile = TMP . 'test-not-image.txt';
+        file_put_contents($tmpFile, 'This is not an image');
+
+        $file = new UploadedFile(
+            $tmpFile,
+            filesize($tmpFile),
+            UPLOAD_ERR_OK,
+            'test.txt',
+            'text/plain',
+        );
+
+        $this->assertFalse(static::isBelowMaxHeight($file, 400));
+
+        unlink($tmpFile);
+    }
+
+    /**
+     * @return void
+     */
+    public function testDimensionMethodsWithValidImage(): void
+    {
+        $file = new UploadedFile(
+            $this->fileFixtures . 'titus.jpg',
+            filesize($this->fileFixtures . 'titus.jpg'),
+            UPLOAD_ERR_OK,
+            'titus.jpg',
+            'image/jpeg',
+        );
+
+        // titus.jpg is larger than 50px
+        $this->assertTrue(static::isAboveMinWidth($file, 50));
+        $this->assertTrue(static::isAboveMinHeight($file, 50));
+
+        // titus.jpg is larger than 400px wide (based on existing test)
+        $this->assertFalse(static::isBelowMaxWidth($file, 400));
+    }
+}


### PR DESCRIPTION
## Summary

- Handle `getimagesize()` returning `false` for non-image files
- Add `isValidImage()` method for clearer error messages

## Problem

When a file passes the upload validation (`UPLOAD_ERR_OK`) but is not a valid image (e.g., PDF, corrupted file, unsupported format), `getimagesize()` returns `false`.

The current code uses array destructuring directly on the result:
```php
[$imgWidth] = getimagesize($file);
```

This causes a fatal error:
```
Cannot use bool as array in ImageValidationTrait.php on line 28
```

Additionally, if the error is handled, users get confusing messages like "This image should at least be 50px wide" for non-image uploads.

## Solution

1. **Fix the crash**: Store the result and check for `false` before accessing dimensions in all four dimension methods.

2. **Add `isValidImage()` method**: Allows explicit validation before dimension checks, enabling clear messages like "File must be a valid image (JPEG, PNG, GIF, or WebP)".

### Usage

```php
$validator->add('file', 'fileIsValidImage', [
    'rule' => 'isValidImage',
    'message' => 'File must be a valid image (JPEG, PNG, GIF, or WebP)',
    'provider' => 'upload',
]);

// Or with custom allowed types:
$validator->add('file', 'fileIsValidImage', [
    'rule' => ['isValidImage', [IMAGETYPE_JPEG, IMAGETYPE_PNG]],
    'message' => 'File must be a JPEG or PNG image',
    'provider' => 'upload',
]);
```