### PR TITLE
Fix loose comparisons in documentation examples

### DIFF
--- a/docs/Documentation/Validation.md
+++ b/docs/Documentation/Validation.md
@@ -40,7 +40,7 @@ class ImageValidator implements UploadValidatorInterface
             'provider' => 'upload',
             'on' => function($context) {
                 $file = $context['data']['file'] ?? null;
-                return $file && $file->getError() == UPLOAD_ERR_OK;
+                return $file && $file->getError() === UPLOAD_ERR_OK;
             },
         ]);
 
@@ -50,7 +50,7 @@ class ImageValidator implements UploadValidatorInterface
             'provider' => 'upload',
             'on' => function($context) {
                 $file = $context['data']['file'] ?? null;
-                return $file && $file->getError() == UPLOAD_ERR_OK;
+                return $file && $file->getError() === UPLOAD_ERR_OK;
             },
         ]);
         $validator->add('file', 'fileAboveMinWidth', [
@@ -59,7 +59,7 @@ class ImageValidator implements UploadValidatorInterface
             'provider' => 'upload',
             'on' => function($context) {
                 $file = $context['data']['file'] ?? null;
-                return $file && $file->getError() == UPLOAD_ERR_OK;
+                return $file && $file->getError() === UPLOAD_ERR_OK;
             },
         ]);
     }


### PR DESCRIPTION
## Summary

- Use strict comparison `===` instead of `==` for `UPLOAD_ERR_OK` checks in validation examples