### PR TITLE
Fix ImageManager constructor for Intervention Image v3

### DIFF
--- a/docs/Documentation/How-To-Use.md
+++ b/docs/Documentation/How-To-Use.md
@@ -301,12 +301,13 @@ Image variants allow you to automatically generate different sizes/versions of u
 In your bootstrap/storage config:
 
 ```php
+use Intervention\Image\Drivers\Gd\Driver;
 use Intervention\Image\ImageManager;
 use PhpCollective\Infrastructure\Storage\Processor\Image\ImageProcessor;
 use PhpCollective\Infrastructure\Storage\Processor\Image\ImageVariantCollection;
 
-// Image Manager
-$imageManager = new ImageManager(['driver' => 'gd']);
+// Image Manager (Intervention Image v3)
+$imageManager = new ImageManager(new Driver());
 
 // Image Processor
 $imageProcessor = new ImageProcessor($fileStorage, $pathBuilder, $imageManager);

--- a/docs/Documentation/Image-Storage-And-Versioning.md
+++ b/docs/Documentation/Image-Storage-And-Versioning.md
@@ -105,11 +105,12 @@ Configure::write('FileStorage', [
 Configure the image processor in your bootstrap or storage configuration:
 
 ```php
+use Intervention\Image\Drivers\Gd\Driver;
 use Intervention\Image\ImageManager;
 use PhpCollective\Infrastructure\Storage\Processor\Image\ImageProcessor;
 
-// Create image manager (uses GD by default)
-$imageManager = new ImageManager();
+// Create image manager with GD driver
+$imageManager = new ImageManager(new Driver());
 
 // Create image processor
 $imageProcessor = new ImageProcessor(

--- a/docs/Tutorials/Quick-Start.md
+++ b/docs/Tutorials/Quick-Start.md
@@ -63,8 +63,10 @@ $fileStorage = new \PhpCollective\Infrastructure\Storage\FileStorage(
     $pathBuilder,
 );
 
-// Image Manager and Processor
-$imageManager = new \Intervention\Image\ImageManager();
+// Image Manager and Processor (Intervention Image v3)
+$imageManager = new \Intervention\Image\ImageManager(
+    new \Intervention\Image\Drivers\Gd\Driver()
+);
 $imageProcessor = new \PhpCollective\Infrastructure\Storage\Processor\Image\ImageProcessor(
     $fileStorage,
     $pathBuilder,


### PR DESCRIPTION
## Summary
- Update documentation to use proper Intervention Image v3 syntax
- ImageManager now requires a Driver object instead of array config or empty constructor
- Updated in: How-To-Use.md, Image-Storage-And-Versioning.md, Quick-Start.md