### PR TITLE
Make admin UI CSP-compatible (nonce inline scripts, drop inline onclick)

### DIFF
--- a/templates/Admin/FileStorage/edit.php
+++ b/templates/Admin/FileStorage/edit.php
@@ -3,15 +3,22 @@
  * @var \App\View\AppView $this
  * @var \FileStorage\Model\Entity\FileStorage $fileStorage
  */
+$cspNonce = (string)$this->getRequest()->getAttribute('cspNonce', '');
 ?>
 <div class="row">
     <aside class="column large-3 medium-4 columns col-sm-4 col-12">
         <ul class="side-nav nav nav-pills flex-column">
             <li class="nav-item heading"><?= __('Actions') ?></li>
-            <li class="nav-item"><?= $this->Form->postLink(
+            <li class="nav-item"><?= $this->Form->postButton(
                 __('Delete'),
                 ['action' => 'delete', $fileStorage->id],
-                ['confirm' => __('Are you sure you want to delete # {0}?', $fileStorage->id), 'class' => 'side-nav-item']
+                [
+                    'class' => 'side-nav-item btn btn-link text-start w-100',
+                    'form' => [
+                        'class' => 'd-inline',
+                        'data-confirm-message' => __('Are you sure you want to delete # {0}?', $fileStorage->id),
+                    ],
+                ]
                 ) ?></li>
             <li class="nav-item"><?= $this->Html->link(__('List File Storage'), ['action' => 'index'], ['class' => 'side-nav-item']) ?></li>
         </ul>
@@ -40,3 +47,12 @@
         </div>
     </div>
 </div>
+<script<?= $cspNonce !== '' ? ' nonce="' . h($cspNonce) . '"' : '' ?>>
+document.querySelectorAll('form[data-confirm-message]').forEach(function(form) {
+    form.addEventListener('submit', function(e) {
+        if (!confirm(this.dataset.confirmMessage)) {
+            e.preventDefault();
+        }
+    });
+});
+</script>

--- a/templates/Admin/FileStorage/index.php
+++ b/templates/Admin/FileStorage/index.php
@@ -4,6 +4,8 @@
  * @var \Cake\Datasource\EntityInterface[]|\Cake\Collection\CollectionInterface $fileStorage
  */
 use Cake\Core\Plugin;
+
+$cspNonce = (string)$this->getRequest()->getAttribute('cspNonce', '');
 ?>
 <nav class="actions large-3 medium-4 columns col-sm-4 col-xs-12" id="actions-sidebar">
     <ul class="side-nav nav nav-pills flex-column">
@@ -53,7 +55,14 @@ use Cake\Core\Plugin;
                     <td class="actions">
                         <?= $this->Html->link(Plugin::isLoaded('Tools') ? $this->Icon->render('view') : __('View'), ['action' => 'view', $fileStorage->id], ['escapeTitle' => false]); ?>
                         <?= $this->Html->link(Plugin::isLoaded('Tools') ? $this->Icon->render('edit') : __('Edit'), ['action' => 'edit', $fileStorage->id], ['escapeTitle' => false]); ?>
-                        <?= $this->Form->postLink(Plugin::isLoaded('Tools') ? $this->Icon->render('delete') : __('Delete'), ['action' => 'delete', $fileStorage->id], ['escapeTitle' => false, 'confirm' => __('Are you sure you want to delete # {0}?', $fileStorage->id)]); ?>
+                        <?= $this->Form->postButton(Plugin::isLoaded('Tools') ? $this->Icon->render('delete') : __('Delete'), ['action' => 'delete', $fileStorage->id], [
+                            'escapeTitle' => false,
+                            'class' => 'btn btn-link p-0 align-baseline',
+                            'form' => [
+                                'class' => 'd-inline',
+                                'data-confirm-message' => __('Are you sure you want to delete # {0}?', $fileStorage->id),
+                            ],
+                        ]); ?>
                     </td>
                 </tr>
                 <?php } ?>
@@ -63,3 +72,12 @@ use Cake\Core\Plugin;
 
     <?php echo $this->element('Tools.pagination'); ?>
 </div>
+<script<?= $cspNonce !== '' ? ' nonce="' . h($cspNonce) . '"' : '' ?>>
+document.querySelectorAll('form[data-confirm-message]').forEach(function(form) {
+    form.addEventListener('submit', function(e) {
+        if (!confirm(this.dataset.confirmMessage)) {
+            e.preventDefault();
+        }
+    });
+});
+</script>

--- a/templates/Admin/FileStorage/view.php
+++ b/templates/Admin/FileStorage/view.php
@@ -6,13 +6,20 @@
 
 use Brick\VarExporter\VarExporter;
 
+$cspNonce = (string)$this->getRequest()->getAttribute('cspNonce', '');
 ?>
 <div class="row">
     <aside class="column actions large-3 medium-4 col-sm-4 col-xs-12">
         <ul class="side-nav nav nav-pills flex-column">
             <li class="nav-item heading"><?= __('Actions') ?></li>
             <li class="nav-item"><?= $this->Html->link(__('Edit {0}', __('File Storage')), ['action' => 'edit', $fileStorage->id], ['class' => 'side-nav-item']) ?></li>
-            <li class="nav-item"><?= $this->Form->postLink(__('Delete {0}', __('File Storage')), ['action' => 'delete', $fileStorage->id], ['confirm' => __('Are you sure you want to delete # {0}?', $fileStorage->id), 'class' => 'side-nav-item']) ?></li>
+            <li class="nav-item"><?= $this->Form->postButton(__('Delete {0}', __('File Storage')), ['action' => 'delete', $fileStorage->id], [
+                'class' => 'side-nav-item btn btn-link text-start w-100',
+                'form' => [
+                    'class' => 'd-inline',
+                    'data-confirm-message' => __('Are you sure you want to delete # {0}?', $fileStorage->id),
+                ],
+            ]) ?></li>
             <li class="nav-item"><?= $this->Html->link(__('List {0}', __('File Storage')), ['action' => 'index'], ['class' => 'side-nav-item']) ?></li>
         </ul>
     </aside>
@@ -77,3 +84,12 @@ use Brick\VarExporter\VarExporter;
         </div>
     </div>
 </div>
+<script<?= $cspNonce !== '' ? ' nonce="' . h($cspNonce) . '"' : '' ?>>
+document.querySelectorAll('form[data-confirm-message]').forEach(function(form) {
+    form.addEventListener('submit', function(e) {
+        if (!confirm(this.dataset.confirmMessage)) {
+            e.preventDefault();
+        }
+    });
+});
+</script>


### PR DESCRIPTION
## Summary

- Replace 3 `Form->postLink` + `confirm` calls with `Form->postButton` + `data-confirm-message`.
- Add nonce-aware inline `<script>` blocks that delegate confirmation handling via `form[data-confirm-message]`.

## Motivation

Under a strict Content-Security-Policy with `script-src 'self' 'nonce-...'`, inline `<script>` blocks without `nonce` and inline event handlers (`onclick=`, etc.) are blocked by the browser. Per the CSP spec, the `nonce` keyword applies ONLY to inline `<script>` / `<style>` blocks — not to event-handler attributes. `$this->Form->postLink(...)` emits `onclick="document.post_X.submit(); ..."` and is therefore unsafe under strict CSP.

## Changes

- Replace 3 `Form->postLink` calls (`edit.php`, `view.php`, `index.php`) with `Form->postButton` (preserves the confirmation UX via `form[data-confirm-message]` + a JS delegate).
- Add 3 inline `<script>` blocks with `nonce` (one per admin template) that attach the delegated `submit` listener.

The plugin has no dedicated layout, so the delegate lives in the individual admin templates that render `postButton` forms.

## Host app nonce setup

Apps that want to benefit need to set a `cspNonce` request attribute in a middleware, e.g.:

```php
$nonce = base64_encode(random_bytes(16));
$request = $request->withAttribute('cspNonce', $nonce);
$response = $response->withHeader(
    'Content-Security-Policy',
    "script-src 'self' 'nonce-{$nonce}'"
);
```

If no `cspNonce` attribute is present, the `<script>` tag falls back to rendering without `nonce` — apps on permissive CSP continue to work unchanged.

## Before / after

```diff
- <?= $this->Form->postLink(__('Delete'), ['action' => 'delete', $fileStorage->id], [
-     'confirm' => __('Are you sure you want to delete # {0}?', $fileStorage->id),
-     'class' => 'side-nav-item',
- ]) ?>
+ <?= $this->Form->postButton(__('Delete'), ['action' => 'delete', $fileStorage->id], [
+     'class' => 'side-nav-item btn btn-link text-start w-100',
+     'form' => [
+         'class' => 'd-inline',
+         'data-confirm-message' => __('Are you sure you want to delete # {0}?', $fileStorage->id),
+     ],
+ ]) ?>
```
