### PR TITLE
Audit fixes: security, performance, modernization (batch 1)

### DIFF
--- a/src/Command/CleanupCommand.php
+++ b/src/Command/CleanupCommand.php
@@ -57,11 +57,14 @@ class CleanupCommand extends Command
      */
     protected function removeOrphanedFiles(array $images, Arguments $args, ConsoleIo $io): void
     {
+        // Hash-set keyed by absolute path for O(1) lookup; the iterator below can scan
+        // many thousand files, and the original `in_array()` walk turned that into O(n*m).
         $files = [];
+        $pathPrefix = (string)Configure::read('FileStorage.pathPrefix');
         foreach ($images as $image) {
-            $files[] = WWW_ROOT . Configure::read('FileStorage.pathPrefix') . $image->path;
+            $files[WWW_ROOT . $pathPrefix . $image->path] = true;
             foreach ($image->variants as $variant => $details) {
-                $files[] = WWW_ROOT . Configure::read('FileStorage.pathPrefix') . $details['path'];
+                $files[WWW_ROOT . $pathPrefix . $details['path']] = true;
             }
         }
 
@@ -108,7 +111,7 @@ class CleanupCommand extends Command
                 continue;
             }
 
-            if (in_array($filePath, $files)) {
+            if (isset($files[$filePath])) {
                 continue;
             }
 

--- a/src/Command/ImageVariantGenerateCommand.php
+++ b/src/Command/ImageVariantGenerateCommand.php
@@ -30,22 +30,17 @@ class ImageVariantGenerateCommand extends Command
 
     /**
      * Storage Table Object
-     *
-     * @var \Cake\ORM\Table
      */
-    protected $Table;
+    protected Table $Table;
 
-    /**
-     * @var int
-     */
-    protected $limit = 10;
+    protected int $limit = 10;
 
     /**
      * Default config
      *
      * @var array<string, mixed>
      */
-    protected $_defaultConfig = [
+    protected array $_defaultConfig = [
         'defaultStorageConfig' => 'Local',
         'ignoreEmptyFile' => true,
         'fileField' => 'file',
@@ -54,15 +49,9 @@ class ImageVariantGenerateCommand extends Command
         'fileValidator' => null,
     ];
 
-    /**
-     * @var \FileStorage\FileStorage\DataTransformerInterface|null
-     */
-    protected $transformer;
+    protected ?DataTransformerInterface $transformer = null;
 
-    /**
-     * @var \PhpCollective\Infrastructure\Storage\Processor\ProcessorInterface|null
-     */
-    protected $processor;
+    protected ?ProcessorInterface $processor = null;
 
     /**
      * Implement this method with your command's logic.
@@ -279,13 +268,10 @@ class ImageVariantGenerateCommand extends Command
             return $this->transformer;
         }
 
-        if (!$this->getConfig('dataTransformer') instanceof DataTransformerInterface) {
-            $this->transformer = new DataTransformer(
-                $this->table(),
-            );
-        }
-
-        assert($this->transformer !== null);
+        $configured = $this->getConfig('dataTransformer');
+        $this->transformer = $configured instanceof DataTransformerInterface
+            ? $configured
+            : new DataTransformer($this->table());
 
         return $this->transformer;
     }

--- a/src/Controller/Admin/FileStorageController.php
+++ b/src/Controller/Admin/FileStorageController.php
@@ -78,6 +78,10 @@ class FileStorageController extends AppController
             return $this->redirect($this->referer(['action' => 'index']));
         }
 
-        return $this->redirect($redirect ?: ['action' => 'index']);
+        if (is_string($redirect) && str_starts_with($redirect, '/') && !str_starts_with($redirect, '//') && !str_starts_with($redirect, '/\\')) {
+            return $this->redirect($redirect);
+        }
+
+        return $this->redirect(['action' => 'index']);
     }
 }

--- a/src/Filesystem/Folder.php
+++ b/src/Filesystem/Folder.php
@@ -571,7 +571,7 @@ class Folder
         foreach ($iterator as $itemPath => $fsIterator) {
             if ($skipHidden) {
                 $subPathName = $fsIterator->getSubPathname();
-                if ($subPathName[0] === '.' || strpos($subPathName, DIRECTORY_SEPARATOR . '.') !== false) {
+                if ($subPathName[0] === '.' || str_contains($subPathName, DIRECTORY_SEPARATOR . '.')) {
                     unset($fsIterator);
 
                     continue;
@@ -937,20 +937,29 @@ class Folder
     }
 
     /**
-     * Get the real path (taking ".." and such into account)
+     * Get the real path (taking ".." and such into account).
+     *
+     * When the Folder already has a `pwd()` set, the resolved path must stay within
+     * that boundary; any input that canonicalizes to a location outside `pwd()` is
+     * rejected with `false`. This containment check is skipped before the first
+     * `cd()` call, so the constructor's initial seeding still works.
      *
      * @param string $path Path to resolve
      *
      * @return string|false The resolved path
      */
-    public function realpath($path)
+    public function realpath(string $path)
     {
-        if (strpos($path, '..') === false) {
+        if (!str_contains($path, '..')) {
             if (!static::isAbsolute($path)) {
                 $path = static::addPathElement((string)$this->path, $path);
             }
 
-            return $path;
+            return $this->withinPath($path);
+        }
+
+        if (!static::isAbsolute($path) && $this->path !== null) {
+            $path = static::addPathElement($this->path, $path);
         }
         $path = str_replace('/', DIRECTORY_SEPARATOR, trim($path));
         $parts = explode(DIRECTORY_SEPARATOR, $path);
@@ -977,7 +986,28 @@ class Folder
         }
         $newpath .= implode(DIRECTORY_SEPARATOR, $newparts);
 
-        return static::slashTerm($newpath);
+        return $this->withinPath(static::slashTerm($newpath));
+    }
+
+    /**
+     * Returns the given resolved path if it is contained within the current `pwd()`,
+     * or `false` otherwise. When `pwd()` is not yet set, the path is returned as-is.
+     *
+     * @param string $path Already-resolved path to check
+     *
+     * @return string|false
+     */
+    protected function withinPath(string $path)
+    {
+        if ($this->path === null || $this->path === '') {
+            return $path;
+        }
+
+        if (!str_starts_with($path, $this->path)) {
+            return false;
+        }
+
+        return $path;
     }
 
     /**

--- a/src/Model/Behavior/FileAssociationBehavior.php
+++ b/src/Model/Behavior/FileAssociationBehavior.php
@@ -218,7 +218,7 @@ class FileAssociationBehavior extends Behavior
         $key = $this->table()->{$association}->getPrimaryKey();
         /** @var string $foreignKey */
         $foreignKey = $this->table()->getPrimaryKey();
-        $entities = $this->table()->{$association}->find()->where(
+        $existingEntities = $this->table()->{$association}->find()->where(
             [
                 'model' => $assocConfig['model'],
                 'collection' => $assocConfig['collection'] ?? null,
@@ -226,8 +226,8 @@ class FileAssociationBehavior extends Behavior
                 'id !=' => $fileEntity->get($key),
             ],
         )->all()->toArray();
-        foreach ($entities as $entity) {
-            $this->table()->{$association}->delete($entity);
+        foreach ($existingEntities as $existing) {
+            $this->table()->{$association}->delete($existing);
         }
     }
 }

--- a/src/Model/Behavior/FileStorageBehavior.php
+++ b/src/Model/Behavior/FileStorageBehavior.php
@@ -29,20 +29,11 @@ class FileStorageBehavior extends Behavior
 {
     use EventDispatcherTrait;
 
-    /**
-     * @var \PhpCollective\Infrastructure\Storage\FileStorage
-     */
-    protected $fileStorage;
+    protected FileStorage $fileStorage;
 
-    /**
-     * @var \FileStorage\FileStorage\DataTransformerInterface
-     */
-    protected $transformer;
+    protected ?DataTransformerInterface $transformer = null;
 
-    /**
-     * @var \PhpCollective\Infrastructure\Storage\Processor\ProcessorInterface
-     */
-    protected $processor;
+    protected ?ProcessorInterface $processor = null;
 
     /**
      * Default config

--- a/src/Model/Validation/UploadValidationTrait.php
+++ b/src/Model/Validation/UploadValidationTrait.php
@@ -122,4 +122,102 @@ trait UploadValidationTrait
 
         return !empty($check['size']) && $check['size'] <= $size;
     }
+
+    /**
+     * Check that the uploaded file's extension is in the given allow-list (case-insensitive).
+     *
+     * Reads the client-supplied filename, so callers SHOULD also pair this with
+     * {@see self::hasAllowedMimeType()} (server-side sniffing) to defeat spoofing.
+     *
+     * @param \Psr\Http\Message\UploadedFileInterface|array $check Value to check
+     * @param array<string> $extensions Allowed extensions, without the leading dot, e.g. `['jpg', 'png']`.
+     *
+     * @return bool
+     */
+    public static function hasAllowedExtension($check, array $extensions): bool
+    {
+        if (!$extensions) {
+            return false;
+        }
+
+        if ($check instanceof UploadedFileInterface) {
+            $name = $check->getClientFilename();
+        } else {
+            $name = $check['name'] ?? null;
+        }
+        if (!is_string($name) || $name === '') {
+            return false;
+        }
+
+        $extension = strtolower((string)pathinfo($name, PATHINFO_EXTENSION));
+        if ($extension === '') {
+            return false;
+        }
+
+        $allowed = array_map(static fn (string $ext): string => strtolower(ltrim($ext, '.')), $extensions);
+
+        return in_array($extension, $allowed, true);
+    }
+
+    /**
+     * Check that the upload's MIME type is in the given allow-list.
+     *
+     * By default, sniffs the MIME type server-side via finfo against the actual file
+     * contents — the client-supplied `Content-Type` header is user-controlled and not
+     * trustworthy. Pass `$sniff = false` to fall back to the client header (only
+     * acceptable when the file is already on a trusted path, e.g. tests).
+     *
+     * @param \Psr\Http\Message\UploadedFileInterface|array $check Value to check
+     * @param array<string> $mimes Allowed MIME types, e.g. `['image/jpeg', 'image/png']`.
+     * @param bool $sniff Whether to sniff the file contents server-side. Defaults to true.
+     *
+     * @return bool
+     */
+    public static function hasAllowedMimeType($check, array $mimes, bool $sniff = true): bool
+    {
+        if (!$mimes) {
+            return false;
+        }
+
+        if ($check instanceof UploadedFileInterface) {
+            $tmpName = null;
+            $clientMime = $check->getClientMediaType();
+        } else {
+            $tmpName = $check['tmp_name'] ?? null;
+            $clientMime = $check['type'] ?? null;
+        }
+
+        $allowed = array_map('strtolower', $mimes);
+
+        if ($sniff && function_exists('finfo_open')) {
+            $path = $tmpName;
+            if ($check instanceof UploadedFileInterface) {
+                $stream = $check->getStream();
+                $meta = $stream->getMetadata('uri');
+                if (is_string($meta)) {
+                    $path = $meta;
+                }
+            }
+
+            if (is_string($path) && $path !== '' && is_file($path)) {
+                $finfo = finfo_open(FILEINFO_MIME_TYPE);
+                if ($finfo !== false) {
+                    try {
+                        $sniffed = finfo_file($finfo, $path);
+                    } finally {
+                        finfo_close($finfo);
+                    }
+                    if (is_string($sniffed) && $sniffed !== '') {
+                        return in_array(strtolower($sniffed), $allowed, true);
+                    }
+                }
+            }
+        }
+
+        if (!is_string($clientMime) || $clientMime === '') {
+            return false;
+        }
+
+        return in_array(strtolower($clientMime), $allowed, true);
+    }
 }

--- a/src/Utility/StorageUtils.php
+++ b/src/Utility/StorageUtils.php
@@ -2,6 +2,7 @@
 
 namespace FileStorage\Utility;
 
+use InvalidArgumentException;
 use Laminas\Diactoros\UploadedFile;
 use Psr\Http\Message\UploadedFileInterface;
 
@@ -15,9 +16,11 @@ class StorageUtils
      */
     public static function fileToUploadedFileObject(string $filename, ?string $mimeType = null): UploadedFileInterface
     {
+        $size = static::assertReadableFile($filename);
+
         return new UploadedFile(
             $filename,
-            (int)filesize($filename),
+            $size,
             UPLOAD_ERR_OK,
             basename($filename),
             $mimeType,
@@ -32,12 +35,36 @@ class StorageUtils
      */
     public static function fileToUploadedFileArray(string $filename, ?string $mimeType = null): array
     {
+        $size = static::assertReadableFile($filename);
+
         return [
             'tmp_name' => $filename,
-            'size' => filesize($filename),
+            'size' => $size,
             'error' => UPLOAD_ERR_OK,
             'name' => basename($filename),
             'type' => $mimeType,
         ];
+    }
+
+    /**
+     * @param string $filename
+     *
+     * @throws \InvalidArgumentException When $filename does not point to a readable regular file.
+     *
+     * @return int Verified file size in bytes.
+     */
+    protected static function assertReadableFile(string $filename): int
+    {
+        clearstatcache(true, $filename);
+        if (!is_file($filename) || !is_readable($filename)) {
+            throw new InvalidArgumentException(sprintf('File `%s` is not a readable file.', $filename));
+        }
+
+        $size = filesize($filename);
+        if ($size === false) {
+            throw new InvalidArgumentException(sprintf('Cannot determine size of file `%s`.', $filename));
+        }
+
+        return $size;
     }
 }

--- a/tests/TestCase/Model/Validation/UploadValidationTraitTest.php
+++ b/tests/TestCase/Model/Validation/UploadValidationTraitTest.php
@@ -1,0 +1,138 @@
+<?php declare(strict_types=1);
+
+namespace FileStorage\Test\TestCase\Model\Validation;
+
+use Cake\TestSuite\TestCase;
+use FileStorage\Model\Validation\UploadValidationTrait;
+use Laminas\Diactoros\UploadedFile;
+use Psr\Http\Message\UploadedFileInterface;
+
+class UploadValidationTraitTest extends TestCase
+{
+    use UploadValidationTrait;
+
+    /**
+     * @return void
+     */
+    public function testHasAllowedExtensionAcceptsArrayUploadInList(): void
+    {
+        $check = ['name' => 'photo.JPG', 'tmp_name' => '/tmp/x', 'type' => 'image/jpeg'];
+
+        $this->assertTrue(self::hasAllowedExtension($check, ['jpg', 'png']));
+    }
+
+    /**
+     * @return void
+     */
+    public function testHasAllowedExtensionRejectsExtensionNotInList(): void
+    {
+        $check = ['name' => 'doc.pdf'];
+
+        $this->assertFalse(self::hasAllowedExtension($check, ['jpg', 'png']));
+    }
+
+    /**
+     * @return void
+     */
+    public function testHasAllowedExtensionRejectsEmptyAllowList(): void
+    {
+        $check = ['name' => 'photo.jpg'];
+
+        $this->assertFalse(self::hasAllowedExtension($check, []));
+    }
+
+    /**
+     * @return void
+     */
+    public function testHasAllowedExtensionRejectsMissingExtension(): void
+    {
+        $check = ['name' => 'README'];
+
+        $this->assertFalse(self::hasAllowedExtension($check, ['jpg']));
+    }
+
+    /**
+     * @return void
+     */
+    public function testHasAllowedExtensionAcceptsLeadingDotInAllowList(): void
+    {
+        $check = ['name' => 'photo.jpg'];
+
+        $this->assertTrue(self::hasAllowedExtension($check, ['.jpg']));
+    }
+
+    /**
+     * @return void
+     */
+    public function testHasAllowedExtensionWorksWithUploadedFileInterface(): void
+    {
+        $upload = $this->makeUploadedFile('photo.png');
+
+        $this->assertTrue(self::hasAllowedExtension($upload, ['png']));
+        $this->assertFalse(self::hasAllowedExtension($upload, ['gif']));
+    }
+
+    /**
+     * @return void
+     */
+    public function testHasAllowedMimeTypeSniffsFromContents(): void
+    {
+        $tmp = $this->createTempFile("\xFF\xD8\xFF\xE0\x00\x10JFIF\x00", 'jpg');
+        $check = ['name' => 'fake.txt', 'tmp_name' => $tmp, 'type' => 'text/plain'];
+
+        $this->assertTrue(self::hasAllowedMimeType($check, ['image/jpeg']));
+        $this->assertFalse(self::hasAllowedMimeType($check, ['image/png']));
+
+        unlink($tmp);
+    }
+
+    /**
+     * @return void
+     */
+    public function testHasAllowedMimeTypeFallsBackToClientHeaderWhenSniffDisabled(): void
+    {
+        $tmp = $this->createTempFile('plain text content', 'txt');
+        $check = ['name' => 'shell.txt', 'tmp_name' => $tmp, 'type' => 'application/x-php'];
+
+        $this->assertTrue(self::hasAllowedMimeType($check, ['application/x-php'], false));
+        $this->assertFalse(self::hasAllowedMimeType($check, ['text/plain'], false));
+
+        unlink($tmp);
+    }
+
+    /**
+     * @return void
+     */
+    public function testHasAllowedMimeTypeRejectsEmptyAllowList(): void
+    {
+        $check = ['name' => 'a.jpg', 'tmp_name' => '', 'type' => 'image/jpeg'];
+
+        $this->assertFalse(self::hasAllowedMimeType($check, []));
+    }
+
+    /**
+     * @param string $contents
+     * @param string $extension
+     *
+     * @return string
+     */
+    protected function createTempFile(string $contents, string $extension): string
+    {
+        $path = TMP . 'upload_validation_' . uniqid() . '.' . $extension;
+        file_put_contents($path, $contents);
+
+        return $path;
+    }
+
+    /**
+     * @param string $clientFilename
+     *
+     * @return \Psr\Http\Message\UploadedFileInterface
+     */
+    protected function makeUploadedFile(string $clientFilename): UploadedFileInterface
+    {
+        $tmp = $this->createTempFile('placeholder', 'bin');
+
+        return new UploadedFile($tmp, filesize($tmp) ?: 0, UPLOAD_ERR_OK, $clientFilename, 'application/octet-stream');
+    }
+}

--- a/tests/TestCase/Utility/StorageUtilsTest.php
+++ b/tests/TestCase/Utility/StorageUtilsTest.php
@@ -4,10 +4,33 @@ namespace FileStorage\Test\TestCase\Utility;
 
 use Cake\TestSuite\TestCase;
 use FileStorage\Utility\StorageUtils;
+use InvalidArgumentException;
 use Psr\Http\Message\UploadedFileInterface;
 
 class StorageUtilsTest extends TestCase
 {
+    /**
+     * @return void
+     */
+    public function testFileToUploadedFileObjectThrowsOnMissingFile(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessageMatches('/not a readable file/');
+
+        StorageUtils::fileToUploadedFileObject(TMP . 'this_file_does_not_exist_' . uniqid() . '.bin');
+    }
+
+    /**
+     * @return void
+     */
+    public function testFileToUploadedFileArrayThrowsOnDirectory(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessageMatches('/not a readable file/');
+
+        StorageUtils::fileToUploadedFileArray(TMP);
+    }
+
     /**
      * @return void
      */


### PR DESCRIPTION
## Summary

Addresses ten findings from a recent audit pass. Bundled because they are independently small and individually mostly one-file changes; happy to split if review prefers.

### Security

- **#1 Open redirect in admin `delete()`** — the action forwarded an arbitrary `?redirect=` query string straight into `Controller::redirect()`, which happily emits a 302 to any absolute URL. Restricted to internal paths only (relative, starting with `/`, not `//` and not `/\`).
- **#3 Path-traversal hardening in `Filesystem\Folder::realpath()`** — after canonicalizing the input, the result must still live under the current `pwd()`. Before the first `cd()` (when `pwd()` is `null`) the check is skipped so the constructor's seeding still works. **Behavior change:** `realpath()` now returns `false` for absolute paths that resolve outside `pwd()` once the folder has been seeded; this matches the documented intent of the class but is a stricter contract than before.
- **#5 `StorageUtils::fileToUploadedFile{Object,Array}()`** validate the source path with `is_file()` + `is_readable()` and throw `InvalidArgumentException` on failure, instead of silently coercing `filesize() === false` into `0` / `false` and producing a corrupted upload entity.
- **#12 New allow-list helpers on `UploadValidationTrait`** — `hasAllowedExtension()` and `hasAllowedMimeType()`. The MIME helper sniffs server-side via `finfo` against the actual file contents by default, since the client-supplied `Content-Type` is user-controlled. Documented in the trait's docblocks; opt-out flag (`$sniff = false`) for tests.

### Performance

- **#4 `CleanupCommand` allowlist** — was an `in_array()` walk over a list, making cleanup O(n*m) on directories with many thousand files. Now an O(1) hash set keyed by absolute path.

### Correctness

- **#14 `ImageVariantGenerateCommand::getTransformer()`** silently dropped a configured `dataTransformer`: the existing branch only assigned the default and ignored the configured value, leaving the field null and tripping the `assert()`. Mirror `FileStorageBehavior::getTransformer()` so the configured transformer wins.
- **#20 `FileAssociationBehavior::findAndRemovePreviousFile()`** — the loop reused `$entity` as the iteration variable, shadowing the outer parameter. Rename to `$existing`. Latent footgun rather than an active bug today, but worth fixing while in the area.

### Modernization

- **#7 `strpos(...) === false`** sites in `Folder` swapped for `str_contains()`.
- **#17 / #18 Typed properties** on `ImageVariantGenerateCommand` (`Table`, `int`, `array`, `?DataTransformerInterface`, `?ProcessorInterface`) and `FileStorageBehavior` (`FileStorage`, `?DataTransformerInterface`, `?ProcessorInterface`).

### Tests

- New `StorageUtilsTest::testFileToUploadedFileObjectThrowsOnMissingFile` and `…ArrayThrowsOnDirectory` for the validation guard.
- New `UploadValidationTraitTest` covering the two allow-list helpers: extension matching (case-insensitive, leading-dot tolerant, both array + `UploadedFileInterface` shapes), MIME sniffing vs. client-header path, empty allow-list rejection.

## Verification

- `vendor/bin/phpunit` — 74 tests, 196 assertions, all green.
- `vendor/bin/phpstan analyze` — clean.
- `vendor/bin/phpcs` — clean (after a `phpcbf` pass for two superfluous `@throws` annotations on the new helpers).
