### PR TITLE
Add fail-closed admin access gate (FileStorage.adminAccess)

### DIFF
--- a/config/app.example.php
+++ b/config/app.example.php
@@ -51,6 +51,15 @@ $collection->addNew('crop')
 return [
     'FileStorage' => [
         'pathPrefix' => 'img/thumbs/',
+        // Admin UI access gate. The admin controller is fail-closed: leaving this unset
+        // (or null) means every action returns 403. Opt in with one of:
+        //
+        //   true                        — trust an upstream gate (Authentication+Authorization,
+        //                                 TinyAuth, custom middleware) on the Admin prefix.
+        //   Closure(ServerRequest $r)   — return true to allow this request.
+        //
+        // See docs/Documentation/Installation.md for examples.
+        'adminAccess' => null,
         // Image variants configuration
         // Structure: [ModelAlias][CollectionName][variants]
         // Note: ModelAlias comes from the table (e.g., 'Posts', 'Users')

--- a/docs/Documentation/Installation.md
+++ b/docs/Documentation/Installation.md
@@ -48,17 +48,61 @@ The plugin uses the FlySystem-based storage abstraction from the `php-collective
 
 ## Setting up backend auth
 
-You can set up backend auth using Authentication/Authorization plugins or e.g. TinyAuth.
+The plugin's `Admin/FileStorageController` is **fail-closed by default**: every action throws
+`ForbiddenException` until you explicitly opt in via the `FileStorage.adminAccess` config key.
+This guarantees that misrouting / forgotten-middleware mistakes return 403 instead of silently
+exposing list / view / edit / delete on the file storage table.
 
-With the latter it is just the following in `config/auth_acl.ini`:
+Pick one of the following depending on your auth stack.
+
+### Option A — upstream gate (Authentication+Authorization plugin, TinyAuth, custom middleware)
+
+Configure your stack to gate the `Admin` prefix the way you normally would, then tell the plugin
+to trust that gate:
+
+```php
+// config/app.php (or any bootstrap file)
+'FileStorage' => [
+    'adminAccess' => true,
+    // … rest of your FileStorage config
+],
 ```
+
+For TinyAuth specifically the per-controller ACL line stays the same:
+```ini
 [FileStorage.Admin/FileStorage]
 * = admin
 ```
-With `admin` being your role that should be able to access it as `/admin/file-storage` via URL.
+With `admin` being the role that should be able to access `/admin/file-storage`.
 
-WARNING: Do not expose the controller actions without any proper auth in place.
-You do not want to make the uploaded content accessible publicly.
+### Option B — inline closure (no auth plugin needed)
+
+If you don't have a full auth stack and just want to gate by identity / role inline:
+
+```php
+'FileStorage' => [
+    'adminAccess' => function (\Cake\Http\ServerRequest $request): bool {
+        $identity = $request->getAttribute('identity');
+
+        return $identity !== null && $identity->is_admin === true;
+    },
+    // …
+],
+```
+
+The closure receives the current `ServerRequest` and must return `true` to allow access.
+Anything else (false, falsy values, exceptions) is treated as deny.
+
+### If you don't want the admin UI at all
+
+Either skip loading the plugin's routes, or load it without routes:
+
+```bash
+bin/cake plugin load FileStorage --no-routes
+```
+
+WARNING: Do not flip `adminAccess` to `true` unless you actually have an upstream gate in place.
+You do not want to make the uploaded content's metadata listable / editable publicly.
 
 Running Tests
 -------------

--- a/src/Controller/Admin/FileStorageController.php
+++ b/src/Controller/Admin/FileStorageController.php
@@ -3,6 +3,10 @@
 namespace FileStorage\Controller\Admin;
 
 use App\Controller\AppController;
+use Cake\Core\Configure;
+use Cake\Event\EventInterface;
+use Cake\Http\Exception\ForbiddenException;
+use Closure;
 
 /**
  * @property \FileStorage\Model\Table\FileStorageTable $FileStorage
@@ -10,6 +14,47 @@ use App\Controller\AppController;
  */
 class FileStorageController extends AppController
 {
+    /**
+     * Fail-closed authorization gate for the admin actions.
+     *
+     * Reads `Configure::read('FileStorage.adminAccess')`:
+     *
+     * - `null` / unset (default) → `ForbiddenException`. Consumers MUST opt in.
+     * - `true` → allow. Use when the host application already gates the `Admin` prefix
+     *   (router scope middleware, Authentication+Authorization plugin, TinyAuth, etc.)
+     *   and you trust that gate to keep unauthorized users out.
+     * - `Closure(\Cake\Http\ServerRequest $request): bool` → allow when the closure
+     *   returns true; deny otherwise. Use when you want to evaluate the current
+     *   identity / role inline without standing up an Authorization stack.
+     *
+     * Anything else (false, string, int, …) is treated as deny.
+     *
+     * @param \Cake\Event\EventInterface $event
+     *
+     * @throws \Cake\Http\Exception\ForbiddenException When access is not explicitly granted.
+     *
+     * @return void
+     */
+    public function beforeFilter(EventInterface $event): void
+    {
+        parent::beforeFilter($event);
+
+        $access = Configure::read('FileStorage.adminAccess');
+        if ($access === true) {
+            return;
+        }
+
+        if ($access instanceof Closure && $access($this->request) === true) {
+            return;
+        }
+
+        throw new ForbiddenException(
+            'Admin access to FileStorage is not configured. Set `FileStorage.adminAccess` to `true` '
+            . '(when an upstream auth gate already protects the `Admin` prefix) '
+            . 'or to a `Closure(\Cake\Http\ServerRequest): bool` to authorize per-request.',
+        );
+    }
+
     /**
      * @return \Cake\Http\Response|null|void Renders view
      */

--- a/tests/TestCase/Controller/Admin/FileStorageControllerTest.php
+++ b/tests/TestCase/Controller/Admin/FileStorageControllerTest.php
@@ -2,6 +2,9 @@
 
 namespace FileStorage\Test\TestCase\Controller\Admin;
 
+use Cake\Core\Configure;
+use Cake\Http\Exception\ForbiddenException;
+use Cake\Http\ServerRequest;
 use Cake\TestSuite\IntegrationTestTrait;
 use Cake\TestSuite\TestCase;
 
@@ -19,6 +22,16 @@ class FileStorageControllerTest extends TestCase
     {
         parent::setUp();
         $this->disableErrorHandlerMiddleware();
+        Configure::write('FileStorage.adminAccess', true);
+    }
+
+    /**
+     * @return void
+     */
+    protected function tearDown(): void
+    {
+        Configure::delete('FileStorage.adminAccess');
+        parent::tearDown();
     }
 
     /**
@@ -100,5 +113,73 @@ class FileStorageControllerTest extends TestCase
 
         $this->assertRedirect(['controller' => 'FileStorage', 'action' => 'index', 'prefix' => 'Admin', 'plugin' => 'FileStorage']);
         $this->assertFlashMessage('The file storage has been deleted.');
+    }
+
+    /**
+     * @return void
+     */
+    public function testIndexForbiddenWhenAdminAccessUnset(): void
+    {
+        Configure::delete('FileStorage.adminAccess');
+
+        $this->expectException(ForbiddenException::class);
+        $this->expectExceptionMessageMatches('/adminAccess/');
+
+        $this->get(['controller' => 'FileStorage', 'action' => 'index', 'prefix' => 'Admin', 'plugin' => 'FileStorage']);
+    }
+
+    /**
+     * @return void
+     */
+    public function testIndexForbiddenWhenAdminAccessFalse(): void
+    {
+        Configure::write('FileStorage.adminAccess', false);
+
+        $this->expectException(ForbiddenException::class);
+
+        $this->get(['controller' => 'FileStorage', 'action' => 'index', 'prefix' => 'Admin', 'plugin' => 'FileStorage']);
+    }
+
+    /**
+     * @return void
+     */
+    public function testIndexForbiddenWhenClosureDenies(): void
+    {
+        Configure::write(
+            'FileStorage.adminAccess',
+            fn (ServerRequest $request): bool => false,
+        );
+
+        $this->expectException(ForbiddenException::class);
+
+        $this->get(['controller' => 'FileStorage', 'action' => 'index', 'prefix' => 'Admin', 'plugin' => 'FileStorage']);
+    }
+
+    /**
+     * @return void
+     */
+    public function testIndexAllowedWhenClosureGrants(): void
+    {
+        Configure::write(
+            'FileStorage.adminAccess',
+            fn (ServerRequest $request): bool => true,
+        );
+
+        $this->get(['controller' => 'FileStorage', 'action' => 'index', 'prefix' => 'Admin', 'plugin' => 'FileStorage']);
+
+        $this->assertResponseOk();
+    }
+
+    /**
+     * @return void
+     */
+    public function testDeleteForbiddenWhenAdminAccessUnset(): void
+    {
+        Configure::delete('FileStorage.adminAccess');
+        $this->enableRetainFlashMessages();
+
+        $this->expectException(ForbiddenException::class);
+
+        $this->post(['controller' => 'FileStorage', 'action' => 'delete', 1, 'prefix' => 'Admin', 'plugin' => 'FileStorage']);
     }
 }


### PR DESCRIPTION
## Summary

Closes the long-standing audit finding that `Admin\FileStorageController` exposed `index` / `view` / `edit` / `delete` with no authorization of its own. The plugin can't know which auth stack a host uses (Authorization plugin, TinyAuth, custom middleware, etc.) but it can refuse to serve until the host explicitly opts in — turning "forgot to gate the `Admin` prefix" from a silent data exposure into a loud 403.

## How it works

`beforeFilter()` reads `Configure::read('FileStorage.adminAccess')`:

| Value                                       | Behaviour                                                                                                  |
|---------------------------------------------|------------------------------------------------------------------------------------------------------------|
| `null` / unset (**default**)                | `ForbiddenException` on every action.                                                                      |
| `true`                                      | Allow. Use when an upstream gate (Authentication+Authorization, TinyAuth, custom middleware) covers Admin. |
| `Closure(ServerRequest $request): bool`     | Allow when the closure returns `true`; deny otherwise.                                                     |
| anything else (`false`, string, int, …)     | Deny.                                                                                                      |

The `Closure` form is intentionally narrow (`Closure`, not `callable`) per the project's PHP rules and to keep the public contract simple.

## BC note ⚠️

Any consumer who currently relies on "the host app gates the `Admin` prefix" will start getting **403 on every admin request after upgrade** until they add `'adminAccess' => true` (or a closure) under the `FileStorage` config block. That is the intended posture — if a reviewer disagrees we should call it out before tagging.

## Files

- `src/Controller/Admin/FileStorageController.php` — `beforeFilter()` reads the new key.
- `docs/Documentation/Installation.md` — replaces the old "Setting up backend auth" section with two clearly-named opt-in modes (upstream gate vs inline closure) plus the no-admin-UI escape hatch.
- `config/app.example.php` — sets `adminAccess => null` with a comment block documenting the options.
- `tests/TestCase/Controller/Admin/FileStorageControllerTest.php` — existing tests now set `adminAccess => true` in `setUp()`; five new tests cover the unset / false / closure-deny / closure-grant / delete-forbidden paths.

## Verification

- `vendor/bin/phpunit` — 79 tests, 202 assertions, all green.
- `vendor/bin/phpstan analyze` — clean.
- `vendor/bin/phpcs` — clean.

Should ship as **4.3.0** (new public config surface + behaviour change). Release-draft to follow.
