### PR TITLE
Standalone admin backend: layout, dashboard, bulk delete, cleanup UI, queued variant regen

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,13 +33,15 @@
     },
     "require-dev": {
         "cakephp/migrations": "^5.0.0",
+        "dereuromark/cakephp-queue": "^8.12",
         "php-collective/code-sniffer": "dev-master",
         "php-collective/file-storage-image-processor": "^1.0 || ^2.0",
         "phpunit/phpunit": "^11.5 || ^12.1 || ^13.0"
     },
     "suggest": {
         "cakephp/migrations": "For migrations to run.",
-        "php-collective/file-storage-image-processor": "Required if you want to use the image processing feature of FileStorage"
+        "php-collective/file-storage-image-processor": "Required if you want to use the image processing feature of FileStorage",
+        "dereuromark/cakephp-queue": "For background image-variant regeneration from the admin UI."
     },
     "conflict": {
         "cakephp/migrations": "<4.5"

--- a/config/app.example.php
+++ b/config/app.example.php
@@ -60,6 +60,23 @@ return [
         //
         // See docs/Documentation/Installation.md for examples.
         'adminAccess' => null,
+
+        // Standalone admin backend. When true the admin controllers run independent of
+        // the host application's `App\Controller\AppController` (skips its initialize()
+        // chain, loads only Flash). Useful for projects without their own admin shell.
+        // Leave false (default) to inherit your AppController's components.
+        'standalone' => false,
+
+        // Bundled Bootstrap 5 / Font Awesome 6 admin layout (CDN with SRI).
+        //   null    — use the bundled `FileStorage.file_storage` layout (default).
+        //   false   — fall back to the host application's default layout
+        //             (matches the pre-4.4 behaviour).
+        //   string  — use the given layout, e.g. `'App.admin'`.
+        'adminLayout' => null,
+        // Optional dependency note:
+        // - The "regenerate variants" button on the admin file listing requires
+        //   `dereuromark/cakephp-queue` to be installed and loaded; the button
+        //   renders disabled (with a tooltip) when Queue is not loaded.
         // Image variants configuration
         // Structure: [ModelAlias][CollectionName][variants]
         // Note: ModelAlias comes from the table (e.g., 'Posts', 'Users')

--- a/docs/Documentation/Installation.md
+++ b/docs/Documentation/Installation.md
@@ -104,6 +104,69 @@ bin/cake plugin load FileStorage --no-routes
 WARNING: Do not flip `adminAccess` to `true` unless you actually have an upstream gate in place.
 You do not want to make the uploaded content's metadata listable / editable publicly.
 
+## The admin backend
+
+Once `adminAccess` is set, the plugin exposes a self-contained admin backend
+under the plugin's `Admin` prefix:
+
+| URL                             | Action                                                        |
+|---------------------------------|---------------------------------------------------------------|
+| `/admin/file-storage`           | Dashboard — counts, total size, top collections/models, recent uploads |
+| `/admin/file-storage/files`     | File listing with bulk delete and (optional) variant regen   |
+| `/admin/file-storage/cleanup`   | Storage-tree cleanup UI — dry-run preview, then confirm      |
+| `/admin/file-storage/dashboard` | Alias for the dashboard                                       |
+| `/admin/file-storage/files/view/{id}` | View a single file_storage entity                       |
+| `/admin/file-storage/files/edit/{id}` | Edit a single file_storage entity                       |
+
+### Layout
+
+The plugin ships its own Bootstrap 5 + Font Awesome 6 layout (loaded via CDN
+with SRI — no webroot bundling). Two config keys control how it integrates
+into your application:
+
+```php
+'FileStorage' => [
+    'adminAccess' => true,
+    // Layout switch:
+    //   null     (default) — use the bundled `FileStorage.file_storage` layout
+    //   false              — fall back to your host app's default layout
+    //   'App.admin'        — use any custom layout you ship
+    'adminLayout' => null,
+
+    // Standalone mode: when true, the admin controllers do NOT call
+    // App\Controller\AppController::initialize() — only Flash is loaded.
+    // Useful for apps without their own admin shell. Default: false (inherit).
+    'standalone' => false,
+],
+```
+
+If you want the admin UI to render inside *your* admin shell (matching the
+pre-4.4 behavior), set `'adminLayout' => false`.
+
+### Cleanup
+
+The admin's **Cleanup** action is the same logic as the existing
+`bin/cake file_storage cleanup` CLI — both delegate to
+`FileStorage\Service\CleanupService`. Use the UI for a dry-run preview
+(orphan rows, orphan files on disk, missing backing files), then confirm to
+run. Use the CLI for cron-driven runs.
+
+### Variant regeneration (optional, requires Queue)
+
+The file listing has a per-row "regenerate variants" button. It's enabled
+when [dereuromark/cakephp-queue](https://github.com/dereuromark/cakephp-queue)
+is installed and loaded; it enqueues a `Queue.Execute` job that runs
+`bin/cake file_storage generate_image_variant ...` on a worker (no
+synchronous regen — long requests would 502).
+
+Without the Queue plugin loaded the button is rendered disabled with a
+tooltip pointing here. Install:
+
+```
+composer require dereuromark/cakephp-queue
+bin/cake plugin load Queue
+```
+
 Running Tests
 -------------
 

--- a/src/Command/CleanupCommand.php
+++ b/src/Command/CleanupCommand.php
@@ -6,11 +6,7 @@ use Cake\Command\Command;
 use Cake\Console\Arguments;
 use Cake\Console\ConsoleIo;
 use Cake\Console\ConsoleOptionParser;
-use Cake\Core\Configure;
-use Exception;
-use FilesystemIterator;
-use RecursiveDirectoryIterator;
-use RecursiveIteratorIterator;
+use FileStorage\Service\CleanupService;
 
 class CleanupCommand extends Command
 {
@@ -24,206 +20,23 @@ class CleanupCommand extends Command
     {
         $model = $args->getArgument('model');
         $collection = $args->getArgument('collection');
+        $dryRun = (bool)$args->getOption('dryRun');
 
-        $conditions = [];
-        if ($model) {
-            $conditions['model'] = $model;
-        }
-        if ($collection) {
-            $conditions['collection'] = $collection;
-        }
+        $report = (new CleanupService())->run($model, $collection, $dryRun);
 
-        $query = $this->getTableLocator()->get('FileStorage.FileStorage')->find()
-            ->where($conditions);
+        $io->out(sprintf('Checking %d file storage rows...', $report->checkedCount));
+        $io->info(sprintf('%d orphan row(s) %s.', $report->deletedRows, $dryRun ? 'would be deleted' : 'deleted'));
 
-        /** @var array<\FileStorage\Model\Entity\FileStorage> $images */
-        $images = $query
-            ->all()
-            ->toArray();
-        $io->out('Checking ' . count($images) . ' images...');
-
-        $this->removeOrphanedImages($args, $io);
-        $this->removeOrphanedFiles($images, $args, $io);
-
-        $this->checkImageFileExistence($images, $args, $io);
-    }
-
-    /**
-     * @param array<\FileStorage\Model\Entity\FileStorage> $images
-     * @param \Cake\Console\Arguments $args
-     * @param \Cake\Console\ConsoleIo $io
-     *
-     * @return void
-     */
-    protected function removeOrphanedFiles(array $images, Arguments $args, ConsoleIo $io): void
-    {
-        // Hash-set keyed by absolute path for O(1) lookup; the iterator below can scan
-        // many thousand files, and the original `in_array()` walk turned that into O(n*m).
-        $files = [];
-        $pathPrefix = (string)Configure::read('FileStorage.pathPrefix');
-        foreach ($images as $image) {
-            $files[WWW_ROOT . $pathPrefix . $image->path] = true;
-            foreach ($image->variants as $variant => $details) {
-                $files[WWW_ROOT . $pathPrefix . $details['path']] = true;
-            }
+        foreach ($report->deletedFiles as $path) {
+            $io->warning(sprintf('%s orphan file: %s', $dryRun ? 'Would delete' : 'Deleted', $path));
         }
 
-        /** @var \PhpCollective\Infrastructure\Storage\FileStorage|null $fileStorage */
-        $fileStorage = Configure::read('FileStorage.behaviorConfig.fileStorage');
-        if (!$fileStorage) {
-            $io->warning('FileStorage not configured, skipping orphaned file removal.');
-
-            return;
+        foreach ($report->missingFiles as $entry) {
+            $io->error(sprintf('Missing files for %s: %s', $entry['id'], implode(', ', $entry['missing'])));
         }
 
-        // Note: This orphaned file removal still requires local filesystem access
-        // as it needs to iterate through directories. For non-local adapters,
-        // this feature may not be applicable.
-        $path = WWW_ROOT . Configure::read('FileStorage.pathPrefix');
-
-        $model = $args->getArgument('model');
-        $collection = $args->getArgument('collection');
-        if ($model) {
-            $path .= $model . DS;
-        }
-        if ($collection) {
-            $path .= $collection . DS;
-        }
-
-        if (!is_dir($path)) {
-            $io->info('Path does not exist or is not accessible: ' . $path);
-
-            return;
-        }
-
-        $directory = new RecursiveDirectoryIterator(
-            $path,
-            FilesystemIterator::SKIP_DOTS,
-        );
-        $contents = new RecursiveIteratorIterator(
-            $directory,
-            RecursiveIteratorIterator::SELF_FIRST,
-        );
-
-        foreach ($contents as $file) {
-            $filePath = (string)$file;
-            if (!is_file($filePath)) {
-                continue;
-            }
-
-            if (isset($files[$filePath])) {
-                continue;
-            }
-
-            $io->warning('Deleting orphaned file: ' . $filePath);
-            if ($args->getOption('dryRun')) {
-                continue;
-            }
-
-            unlink($filePath);
-        }
-    }
-
-    /**
-     * @param \Cake\Console\Arguments $args
-     * @param \Cake\Console\ConsoleIo $io
-     *
-     * @return void
-     */
-    protected function removeOrphanedImages(Arguments $args, ConsoleIo $io): void
-    {
-        $model = $args->getArgument('model');
-        $collection = $args->getArgument('collection');
-        $conditions = [
-            'foreign_key IS' => null,
-        ];
-        if ($model) {
-            $conditions['model'] = $model;
-        }
-        if ($collection) {
-            $conditions['collection'] = $collection;
-        }
-
-        $query = $this->getTableLocator()->get('FileStorage.FileStorage')->find()
-            ->where($conditions);
-
-        /** @var array<\FileStorage\Model\Entity\FileStorage> $images */
-        $images = $query
-            ->all()
-            ->toArray();
-
-        $io->info(count($images) . ' orphaned images found.');
-        if ($args->getOption('dryRun')) {
-            return;
-        }
-
-        foreach ($images as $image) {
-            $io->verbose('- deleting orphaned image ' . $image->id);
-            $this->getTableLocator()->get('FileStorage.FileStorage')->deleteOrFail($image);
-        }
-    }
-
-    /**
-     * @param array<\FileStorage\Model\Entity\FileStorage> $images
-     * @param \Cake\Console\Arguments $args
-     * @param \Cake\Console\ConsoleIo $io
-     *
-     * @return void
-     */
-    protected function checkImageFileExistence(array $images, Arguments $args, ConsoleIo $io): void
-    {
-        /** @var \PhpCollective\Infrastructure\Storage\FileStorage|null $fileStorage */
-        $fileStorage = Configure::read('FileStorage.behaviorConfig.fileStorage');
-        if (!$fileStorage) {
-            $io->warning('FileStorage not configured, skipping existence check.');
-
-            return;
-        }
-
-        foreach ($images as $image) {
-            $io->verbose('Checking image ' . $image->id);
-
-            // Use storage adapter to check file existence
-            if (!$image->adapter || !$image->path) {
-                $io->error('Image ' . $image->id . ' has no adapter or path configured');
-
-                continue;
-            }
-
-            try {
-                $adapter = $fileStorage->getStorage($image->adapter);
-            } catch (Exception $e) {
-                $io->error('Could not get adapter for image ' . $image->id . ': ' . $e->getMessage());
-
-                continue;
-            }
-
-            $missing = [];
-
-            // Check main file
-            if (!$adapter->fileExists($image->path)) {
-                $missing[] = 'main';
-            }
-
-            // Check variants
-            foreach ($image->variants as $variant => $details) {
-                $variantPath = $details['path'] ?? null;
-                if ($variantPath && !$adapter->fileExists($variantPath)) {
-                    $missing[] = $variant;
-                }
-            }
-
-            if (!$missing) {
-                continue;
-            }
-
-            $io->error('Missing files for ' . $image->id . ': ' . implode(', ', $missing));
-            if ($args->getOption('dryRun')) {
-                continue;
-            }
-
-            $this->getTableLocator()->get('FileStorage.FileStorage')->delete($image);
-            $io->verbose('- deleting image ' . $image->id);
+        foreach ($report->warnings as $warning) {
+            $io->warning($warning);
         }
     }
 

--- a/src/Controller/Admin/FileStorageAppController.php
+++ b/src/Controller/Admin/FileStorageAppController.php
@@ -1,0 +1,128 @@
+<?php declare(strict_types=1);
+
+namespace FileStorage\Controller\Admin;
+
+use App\Controller\AppController;
+use Cake\Controller\Controller;
+use Cake\Core\Configure;
+use Cake\Event\EventInterface;
+use Cake\Http\Exception\ForbiddenException;
+use Cake\Log\Log;
+use Closure;
+use Throwable;
+
+/**
+ * Base controller for the FileStorage admin backend.
+ *
+ * Hosts the fail-closed authorization gate (`FileStorage.adminAccess`) and the
+ * standalone-mode / layout switches that make this plugin's admin UI
+ * mountable both inside the host's existing admin shell and as a fully
+ * self-contained backend (Bootstrap 5 + Font Awesome 6 via CDN).
+ *
+ * Configuration keys (all under the `FileStorage.` namespace):
+ *
+ * - `adminAccess` (default: unset → 403)
+ *     Authorization gate. See {@see self::beforeFilter()}.
+ * - `standalone` (default: false)
+ *     When true, skips the host application's `App\Controller\AppController`
+ *     `initialize()` chain and runs against `Cake\Controller\Controller` only.
+ *     Useful for projects without their own admin shell.
+ * - `adminLayout` (default: null)
+ *     - `null` → use the bundled `FileStorage.file_storage` layout.
+ *     - `false` → fall back to the host application's default layout
+ *                  (the pre-4.3 behaviour).
+ *     - `string` → use the given layout (`FileStorage.file_storage` or any custom).
+ */
+class FileStorageAppController extends AppController
+{
+    use LoadHelperTrait;
+
+    /**
+     * @return void
+     */
+    public function initialize(): void
+    {
+        if (Configure::read('FileStorage.standalone') === true) {
+            // Standalone mode: skip the host's AppController chain entirely.
+            Controller::initialize();
+            $this->loadComponent('Flash');
+        } else {
+            parent::initialize();
+        }
+
+        $this->loadFileStorageHelpers();
+
+        $layout = Configure::read('FileStorage.adminLayout');
+        if ($layout !== false) {
+            $this->viewBuilder()->setLayout(is_string($layout) ? $layout : 'FileStorage.file_storage');
+        }
+    }
+
+    /**
+     * Fail-closed authorization gate for the admin actions.
+     *
+     * Reads `Configure::read('FileStorage.adminAccess')`:
+     *
+     * - `null` / unset (default) → `ForbiddenException`. Consumers MUST opt in.
+     * - `true` → allow. Use when an upstream gate (Authentication+Authorization,
+     *   TinyAuth, custom middleware) already protects the `Admin` prefix.
+     * - `Closure(\Cake\Http\ServerRequest): bool` → allow only when the closure
+     *   returns literal `true`.
+     *
+     * Anything else (false, string, int, …) is treated as deny. Any exception
+     * thrown from the closure is logged and converted to a generic 403 — the
+     * gate must not leak internal error detail to unauthenticated callers.
+     *
+     * @param \Cake\Event\EventInterface<\Cake\Controller\Controller> $event
+     *
+     * @throws \Cake\Http\Exception\ForbiddenException When access is not explicitly granted.
+     *
+     * @return void
+     */
+    public function beforeFilter(EventInterface $event): void
+    {
+        parent::beforeFilter($event);
+
+        // Coexist with cakephp/authorization: this gate IS the authorization
+        // decision for the admin controllers, so silence the policy check.
+        if (
+            $this->components()->has('Authorization')
+            && method_exists($this->components()->get('Authorization'), 'skipAuthorization')
+        ) {
+            $this->components()->get('Authorization')->skipAuthorization();
+        }
+
+        $access = Configure::read('FileStorage.adminAccess');
+        if ($access === true) {
+            return;
+        }
+
+        if ($access instanceof Closure) {
+            try {
+                $allowed = $access($this->request) === true;
+            } catch (ForbiddenException $e) {
+                throw $e;
+            } catch (Throwable $e) {
+                Log::warning(sprintf(
+                    'FileStorage.adminAccess threw %s: %s',
+                    $e::class,
+                    $e->getMessage(),
+                ));
+
+                throw new ForbiddenException('FileStorage admin access denied.');
+            }
+
+            if ($allowed) {
+                return;
+            }
+
+            throw new ForbiddenException('FileStorage admin access denied.');
+        }
+
+        throw new ForbiddenException(
+            'Admin access to FileStorage is not configured. Set `FileStorage.adminAccess` to `true` '
+            . '(when an upstream auth gate already protects the `Admin` prefix) '
+            . 'or to a `Closure(\Cake\Http\ServerRequest): bool` to authorize per-request.',
+        );
+    }
+}

--- a/src/Controller/Admin/FileStorageController.php
+++ b/src/Controller/Admin/FileStorageController.php
@@ -2,59 +2,16 @@
 
 namespace FileStorage\Controller\Admin;
 
-use App\Controller\AppController;
-use Cake\Core\Configure;
-use Cake\Event\EventInterface;
-use Cake\Http\Exception\ForbiddenException;
-use Closure;
+use Cake\Core\Plugin;
+use Cake\Http\Exception\BadRequestException;
+use FileStorage\Service\CleanupService;
 
 /**
  * @property \FileStorage\Model\Table\FileStorageTable $FileStorage
  * @method \Cake\Datasource\ResultSetInterface<\FileStorage\Model\Entity\FileStorage> paginate($object = null, array $settings = [])
  */
-class FileStorageController extends AppController
+class FileStorageController extends FileStorageAppController
 {
-    /**
-     * Fail-closed authorization gate for the admin actions.
-     *
-     * Reads `Configure::read('FileStorage.adminAccess')`:
-     *
-     * - `null` / unset (default) → `ForbiddenException`. Consumers MUST opt in.
-     * - `true` → allow. Use when the host application already gates the `Admin` prefix
-     *   (router scope middleware, Authentication+Authorization plugin, TinyAuth, etc.)
-     *   and you trust that gate to keep unauthorized users out.
-     * - `Closure(\Cake\Http\ServerRequest $request): bool` → allow when the closure
-     *   returns true; deny otherwise. Use when you want to evaluate the current
-     *   identity / role inline without standing up an Authorization stack.
-     *
-     * Anything else (false, string, int, …) is treated as deny.
-     *
-     * @param \Cake\Event\EventInterface $event
-     *
-     * @throws \Cake\Http\Exception\ForbiddenException When access is not explicitly granted.
-     *
-     * @return void
-     */
-    public function beforeFilter(EventInterface $event): void
-    {
-        parent::beforeFilter($event);
-
-        $access = Configure::read('FileStorage.adminAccess');
-        if ($access === true) {
-            return;
-        }
-
-        if ($access instanceof Closure && $access($this->request) === true) {
-            return;
-        }
-
-        throw new ForbiddenException(
-            'Admin access to FileStorage is not configured. Set `FileStorage.adminAccess` to `true` '
-            . '(when an upstream auth gate already protects the `Admin` prefix) '
-            . 'or to a `Closure(\Cake\Http\ServerRequest): bool` to authorize per-request.',
-        );
-    }
-
     /**
      * @return \Cake\Http\Response|null|void Renders view
      */
@@ -67,6 +24,7 @@ class FileStorageController extends AppController
         $fileStorage = $this->paginate($this->FileStorage);
 
         $this->set(compact('fileStorage'));
+        $this->set('queueLoaded', Plugin::isLoaded('Queue'));
     }
 
     /**
@@ -81,6 +39,7 @@ class FileStorageController extends AppController
         $fileStorage = $this->FileStorage->get($id);
 
         $this->set(compact('fileStorage'));
+        $this->set('queueLoaded', Plugin::isLoaded('Queue'));
     }
 
     /**
@@ -128,5 +87,149 @@ class FileStorageController extends AppController
         }
 
         return $this->redirect(['action' => 'index']);
+    }
+
+    /**
+     * Bulk delete selected files. Reads an `ids[]` array from POST.
+     *
+     * @return \Cake\Http\Response|null
+     */
+    public function deleteBulk()
+    {
+        $this->request->allowMethod(['post']);
+
+        /** @var array<int, string|int> $ids */
+        $ids = (array)$this->request->getData('ids', []);
+        $ids = array_values(array_filter($ids, static fn ($id): bool => (string)$id !== ''));
+
+        if (!$ids) {
+            $this->Flash->warning(__('No file storage entries selected.'));
+
+            return $this->redirect(['action' => 'index']);
+        }
+
+        $deleted = 0;
+        $failed = 0;
+        foreach ($ids as $id) {
+            $entity = $this->FileStorage->find()->where(['id' => $id])->first();
+            if ($entity === null) {
+                $failed++;
+
+                continue;
+            }
+            if ($this->FileStorage->delete($entity)) {
+                $deleted++;
+            } else {
+                $failed++;
+            }
+        }
+
+        if ($deleted > 0 && $failed === 0) {
+            $this->Flash->success(__n(
+                '{0} file storage entry deleted.',
+                '{0} file storage entries deleted.',
+                $deleted,
+                $deleted,
+            ));
+        } elseif ($deleted > 0 && $failed > 0) {
+            $this->Flash->warning(__('{0} deleted, {1} failed.', $deleted, $failed));
+        } else {
+            $this->Flash->error(__('Bulk delete failed.'));
+        }
+
+        return $this->redirect(['action' => 'index']);
+    }
+
+    /**
+     * Storage-tree cleanup UI on top of the `file_storage cleanup` CLI command.
+     *
+     * GET → renders the form (and a dry-run preview if `model` query is set).
+     * POST → executes the cleanup against the resolved scope.
+     *
+     * @return \Cake\Http\Response|null|void
+     */
+    public function cleanup()
+    {
+        $service = new CleanupService();
+
+        $models = $this->FileStorage
+            ->find()
+            ->select(['model'])
+            ->where(['model IS NOT' => null])
+            ->groupBy(['model'])
+            ->orderByAsc('model')
+            ->all()
+            ->extract('model')
+            ->toArray();
+
+        if ($this->request->is('post')) {
+            $model = (string)$this->request->getData('model') ?: null;
+            $collection = (string)$this->request->getData('collection') ?: null;
+            $report = $service->run($model, $collection, dryRun: false);
+
+            $this->Flash->success(__(
+                'Cleanup complete: {0} orphaned files deleted, {1} orphaned rows removed.',
+                count($report->deletedFiles),
+                $report->deletedRows,
+            ));
+
+            return $this->redirect(['action' => 'cleanup']);
+        }
+
+        $previewModel = (string)$this->request->getQuery('model') ?: null;
+        $previewCollection = (string)$this->request->getQuery('collection') ?: null;
+        $report = null;
+        if ($previewModel !== null || $previewCollection !== null) {
+            $report = $service->run($previewModel, $previewCollection, dryRun: true);
+        }
+
+        $this->set(compact('models', 'report', 'previewModel', 'previewCollection'));
+    }
+
+    /**
+     * Enqueue an image-variant regeneration job. Requires the cakephp-queue
+     * plugin to be loaded — the action returns a 400 otherwise so the UI's
+     * disabled state stays in sync with the runtime check.
+     *
+     * @param string|null $id File Storage id.
+     *
+     * @throws \Cake\Http\Exception\BadRequestException When the Queue plugin is unavailable.
+     *
+     * @return \Cake\Http\Response|null
+     */
+    public function regenerateVariants($id = null)
+    {
+        $this->request->allowMethod(['post']);
+
+        if (!Plugin::isLoaded('Queue')) {
+            throw new BadRequestException(
+                'Variant regeneration requires the cakephp-queue plugin. '
+                . 'Install dereuromark/cakephp-queue to enable this action.',
+            );
+        }
+
+        $entity = $this->FileStorage->get($id);
+
+        // Use Queue's bundled `Execute` task: enqueue a CLI invocation of the
+        // existing `file_storage generate_image_variant` command. This avoids
+        // shipping a custom queue task class (which would couple the plugin
+        // to cakephp-queue at compile time) while still doing the work
+        // out-of-band on a worker.
+        /** @var \Queue\Model\Table\QueuedJobsTable $queuedJobs */
+        $queuedJobs = $this->fetchTable('Queue.QueuedJobs');
+        $queuedJobs->createJob(
+            'Queue.Execute',
+            [
+                'command' => sprintf(
+                    'bin/cake file_storage generate_image_variant %s %s',
+                    escapeshellarg((string)$entity->model),
+                    escapeshellarg((string)$entity->collection),
+                ),
+            ],
+        );
+
+        $this->Flash->success(__('Variant regeneration job has been queued for {0}.', h($entity->filename)));
+
+        return $this->redirect($this->referer(['action' => 'index']));
     }
 }

--- a/src/Controller/Admin/FileStorageDashboardController.php
+++ b/src/Controller/Admin/FileStorageDashboardController.php
@@ -1,0 +1,103 @@
+<?php declare(strict_types=1);
+
+namespace FileStorage\Controller\Admin;
+
+use Cake\Core\Plugin;
+use FileStorage\Model\Table\FileStorageTable;
+
+class FileStorageDashboardController extends FileStorageAppController
+{
+    /**
+     * @var \FileStorage\Model\Table\FileStorageTable
+     */
+    protected FileStorageTable $FileStorage;
+
+    /**
+     * @return void
+     */
+    public function initialize(): void
+    {
+        parent::initialize();
+
+        /** @var \FileStorage\Model\Table\FileStorageTable $table */
+        $table = $this->fetchTable('FileStorage.FileStorage');
+        $this->FileStorage = $table;
+    }
+
+    /**
+     * @return \Cake\Http\Response|null|void
+     */
+    public function index()
+    {
+        $totalCount = $this->FileStorage->find()->count();
+
+        /** @var int|null $totalBytes */
+        $totalBytes = $this->FileStorage->find()
+            ->select(['total' => 'SUM(filesize)'])
+            ->disableHydration()
+            ->all()
+            ->first()['total'] ?? 0;
+
+        $orphanCount = $this->FileStorage->find()
+            ->where(['foreign_key IS' => null])
+            ->count();
+
+        // Top 10 collections by file count
+        $byCollection = $this->FileStorage->find()
+            ->select([
+                'collection',
+                'count' => 'COUNT(*)',
+                'bytes' => 'SUM(filesize)',
+            ])
+            ->where(['collection IS NOT' => null])
+            ->groupBy(['collection'])
+            ->orderByDesc('count')
+            ->limit(10)
+            ->disableHydration()
+            ->all()
+            ->toList();
+
+        $byModel = $this->FileStorage->find()
+            ->select([
+                'model',
+                'count' => 'COUNT(*)',
+                'bytes' => 'SUM(filesize)',
+            ])
+            ->where(['model IS NOT' => null])
+            ->groupBy(['model'])
+            ->orderByDesc('count')
+            ->limit(10)
+            ->disableHydration()
+            ->all()
+            ->toList();
+
+        $byAdapter = $this->FileStorage->find()
+            ->select([
+                'adapter',
+                'count' => 'COUNT(*)',
+            ])
+            ->where(['adapter IS NOT' => null])
+            ->groupBy(['adapter'])
+            ->orderByDesc('count')
+            ->disableHydration()
+            ->all()
+            ->toList();
+
+        $recent = $this->FileStorage->find()
+            ->orderByDesc('created')
+            ->limit(10)
+            ->all()
+            ->toArray();
+
+        $this->set(compact(
+            'totalCount',
+            'totalBytes',
+            'orphanCount',
+            'byCollection',
+            'byModel',
+            'byAdapter',
+            'recent',
+        ));
+        $this->set('queueLoaded', Plugin::isLoaded('Queue'));
+    }
+}

--- a/src/Controller/Admin/LoadHelperTrait.php
+++ b/src/Controller/Admin/LoadHelperTrait.php
@@ -1,0 +1,37 @@
+<?php declare(strict_types=1);
+
+namespace FileStorage\Controller\Admin;
+
+use Cake\Core\Plugin;
+
+/**
+ * Soft-dependency helper bootstrap for the FileStorage admin views.
+ *
+ * Mirrors the pattern used by `cakephp-queue` and `cakephp-tags`: helpers from
+ * sibling utility plugins (Tools, Shim, Templating) are loaded only when those
+ * plugins are present, so the admin UI works with or without them.
+ */
+trait LoadHelperTrait
+{
+    /**
+     * @return void
+     */
+    protected function loadFileStorageHelpers(): void
+    {
+        $helpers = [];
+
+        if (Plugin::isLoaded('Tools')) {
+            $helpers[] = 'Tools.Time';
+            $helpers[] = 'Tools.Format';
+        } else {
+            $helpers[] = 'Time';
+            $helpers[] = 'Number';
+        }
+
+        if (Plugin::isLoaded('Templating')) {
+            $helpers[] = 'Templating.Icon';
+        }
+
+        $this->viewBuilder()->addHelpers($helpers);
+    }
+}

--- a/src/FileStoragePlugin.php
+++ b/src/FileStoragePlugin.php
@@ -39,7 +39,9 @@ class FileStoragePlugin extends BasePlugin
     {
         $routes->prefix('Admin', function (RouteBuilder $routes): void {
             $routes->plugin('FileStorage', ['path' => '/file-storage'], function (RouteBuilder $routes): void {
-                $routes->connect('/', ['controller' => 'FileStorage', 'action' => 'index']);
+                $routes->connect('/', ['controller' => 'FileStorageDashboard', 'action' => 'index']);
+                $routes->connect('/files', ['controller' => 'FileStorage', 'action' => 'index']);
+                $routes->connect('/dashboard', ['controller' => 'FileStorageDashboard', 'action' => 'index']);
 
                 $routes->fallbacks();
             });

--- a/src/Service/CleanupReport.php
+++ b/src/Service/CleanupReport.php
@@ -1,0 +1,32 @@
+<?php declare(strict_types=1);
+
+namespace FileStorage\Service;
+
+/**
+ * Result object returned from {@see CleanupService::run()}.
+ *
+ * Lives as a plain DTO so both the CLI command and the admin UI can format
+ * the same data differently. In dry-run mode `$deletedFiles` and
+ * `$deletedRows` describe what *would* be done, not what was actually done.
+ */
+class CleanupReport
+{
+    /**
+     * @param bool $dryRun Whether the run was a preview.
+     * @param int $checkedCount Number of file_storage rows the run considered.
+     * @param array<int, string> $deletedFiles Absolute paths of orphaned files (would-be) removed.
+     * @param int $deletedRows Number of orphan rows (foreign_key IS NULL) (would-be) deleted.
+     * @param array<int, array{id: string|int, missing: array<int, string>}> $missingFiles
+     *   Rows whose backing files (main and/or variants) are missing on the storage adapter.
+     * @param array<int, string> $warnings Non-fatal messages (e.g. fileStorage adapter not configured).
+     */
+    public function __construct(
+        public readonly bool $dryRun,
+        public readonly int $checkedCount,
+        public readonly array $deletedFiles,
+        public readonly int $deletedRows,
+        public readonly array $missingFiles,
+        public readonly array $warnings,
+    ) {
+    }
+}

--- a/src/Service/CleanupService.php
+++ b/src/Service/CleanupService.php
@@ -1,0 +1,215 @@
+<?php declare(strict_types=1);
+
+namespace FileStorage\Service;
+
+use Cake\Core\Configure;
+use Cake\ORM\Locator\LocatorAwareTrait;
+use Exception;
+use FilesystemIterator;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
+
+/**
+ * Storage-tree cleanup logic, shared between the `file_storage cleanup`
+ * CLI command and the `Admin/FileStorage::cleanup()` action.
+ *
+ * Three responsibilities:
+ *
+ * 1. Delete `file_storage` rows whose `foreign_key` is null (orphan rows).
+ * 2. Walk the configured local filesystem path and remove files that have no
+ *    matching `file_storage` row (orphan files on disk).
+ * 3. Report rows whose backing main/variant files are missing on the
+ *    configured storage adapter (consistency check).
+ *
+ * Dry-run mode performs all the *queries* but skips the actual mutations.
+ */
+class CleanupService
+{
+    use LocatorAwareTrait;
+
+    /**
+     * @param string|null $model Optional model alias filter.
+     * @param string|null $collection Optional collection filter.
+     * @param bool $dryRun When true, no rows or files are actually removed.
+     *
+     * @return \FileStorage\Service\CleanupReport
+     */
+    public function run(?string $model, ?string $collection, bool $dryRun): CleanupReport
+    {
+        $warnings = [];
+        $table = $this->fetchTable('FileStorage.FileStorage');
+
+        $scopeConditions = [];
+        if ($model !== null && $model !== '') {
+            $scopeConditions['model'] = $model;
+        }
+        if ($collection !== null && $collection !== '') {
+            $scopeConditions['collection'] = $collection;
+        }
+
+        /** @var array<\FileStorage\Model\Entity\FileStorage> $images */
+        $images = $table->find()
+            ->where($scopeConditions)
+            ->all()
+            ->toArray();
+
+        $deletedRows = $this->removeOrphanRows($scopeConditions, $dryRun);
+        $deletedFiles = $this->removeOrphanFiles($images, $model, $collection, $dryRun, $warnings);
+        $missingFiles = $this->collectMissingFiles($images, $warnings);
+
+        return new CleanupReport(
+            dryRun: $dryRun,
+            checkedCount: count($images),
+            deletedFiles: $deletedFiles,
+            deletedRows: $deletedRows,
+            missingFiles: $missingFiles,
+            warnings: $warnings,
+        );
+    }
+
+    /**
+     * @param array<string, mixed> $scopeConditions
+     * @param bool $dryRun
+     *
+     * @return int Number of orphan rows deleted (or that would be deleted).
+     */
+    protected function removeOrphanRows(array $scopeConditions, bool $dryRun): int
+    {
+        $table = $this->fetchTable('FileStorage.FileStorage');
+        $conditions = $scopeConditions + ['foreign_key IS' => null];
+
+        /** @var array<\FileStorage\Model\Entity\FileStorage> $orphans */
+        $orphans = $table->find()->where($conditions)->all()->toArray();
+        if ($dryRun) {
+            return count($orphans);
+        }
+
+        $deleted = 0;
+        foreach ($orphans as $orphan) {
+            if ($table->delete($orphan)) {
+                $deleted++;
+            }
+        }
+
+        return $deleted;
+    }
+
+    /**
+     * @param array<\FileStorage\Model\Entity\FileStorage> $images
+     * @param string|null $model
+     * @param string|null $collection
+     * @param bool $dryRun
+     * @param array<int, string> $warnings Out param.
+     *
+     * @return array<int, string> Absolute paths of orphan files on disk that were (or would be) deleted.
+     */
+    protected function removeOrphanFiles(
+        array $images,
+        ?string $model,
+        ?string $collection,
+        bool $dryRun,
+        array &$warnings,
+    ): array {
+        // Hash-set keyed by absolute path for O(1) lookup; the iterator below can scan
+        // many thousand files, and a linear `in_array` walk would turn that into O(n*m).
+        $expected = [];
+        $pathPrefix = (string)Configure::read('FileStorage.pathPrefix');
+        foreach ($images as $image) {
+            $expected[WWW_ROOT . $pathPrefix . $image->path] = true;
+            foreach ($image->variants as $details) {
+                if (isset($details['path'])) {
+                    $expected[WWW_ROOT . $pathPrefix . $details['path']] = true;
+                }
+            }
+        }
+
+        $fileStorage = Configure::read('FileStorage.behaviorConfig.fileStorage');
+        if ($fileStorage === null) {
+            $warnings[] = 'FileStorage adapter not configured, skipping orphaned file removal.';
+
+            return [];
+        }
+
+        $path = WWW_ROOT . $pathPrefix;
+        if ($model !== null && $model !== '') {
+            $path .= $model . DS;
+        }
+        if ($collection !== null && $collection !== '') {
+            $path .= $collection . DS;
+        }
+
+        if (!is_dir($path)) {
+            $warnings[] = sprintf('Path does not exist or is not accessible: %s', $path);
+
+            return [];
+        }
+
+        $iter = new RecursiveIteratorIterator(
+            new RecursiveDirectoryIterator($path, FilesystemIterator::SKIP_DOTS),
+            RecursiveIteratorIterator::SELF_FIRST,
+        );
+
+        $deleted = [];
+        foreach ($iter as $file) {
+            $filePath = (string)$file;
+            if (!is_file($filePath) || isset($expected[$filePath])) {
+                continue;
+            }
+
+            $deleted[] = $filePath;
+            if (!$dryRun) {
+                @unlink($filePath);
+            }
+        }
+
+        return $deleted;
+    }
+
+    /**
+     * @param array<\FileStorage\Model\Entity\FileStorage> $images
+     * @param array<int, string> $warnings Out param.
+     *
+     * @return array<int, array{id: string|int, missing: array<int, string>}>
+     */
+    protected function collectMissingFiles(array $images, array &$warnings): array
+    {
+        $fileStorage = Configure::read('FileStorage.behaviorConfig.fileStorage');
+        if ($fileStorage === null) {
+            $warnings[] = 'FileStorage adapter not configured, skipping existence check.';
+
+            return [];
+        }
+
+        $missing = [];
+        foreach ($images as $image) {
+            if (!$image->adapter || !$image->path) {
+                continue;
+            }
+
+            try {
+                $adapter = $fileStorage->getStorage($image->adapter);
+            } catch (Exception $e) {
+                $warnings[] = sprintf('Could not get adapter for image %s: %s', $image->id, $e->getMessage());
+
+                continue;
+            }
+
+            $missingForImage = [];
+            if (!$adapter->fileExists($image->path)) {
+                $missingForImage[] = 'main';
+            }
+            foreach ($image->variants as $variant => $details) {
+                $variantPath = $details['path'] ?? null;
+                if ($variantPath && !$adapter->fileExists($variantPath)) {
+                    $missingForImage[] = (string)$variant;
+                }
+            }
+
+            if ($missingForImage) {
+                $missing[] = ['id' => $image->id, 'missing' => $missingForImage];
+            }
+        }
+
+        return $missing;
+    }
+}

--- a/templates/Admin/FileStorage/cleanup.php
+++ b/templates/Admin/FileStorage/cleanup.php
@@ -1,0 +1,129 @@
+<?php
+/**
+ * @var \Cake\View\View $this
+ * @var array<int, string> $models
+ * @var \FileStorage\Service\CleanupReport|null $report
+ * @var string|null $previewModel
+ * @var string|null $previewCollection
+ */
+
+use FileStorage\Service\CleanupReport;
+
+$this->assign('title', __d('file_storage', 'Cleanup'));
+?>
+<h1 class="h3 mb-4"><i class="fas fa-broom me-2 text-primary"></i><?= __d('file_storage', 'Storage Cleanup') ?></h1>
+
+<div class="card mb-4">
+    <div class="card-header"><?= __d('file_storage', 'Scope') ?></div>
+    <div class="card-body">
+        <?= $this->Form->create(null, ['type' => 'get', 'class' => 'row g-3 align-items-end']) ?>
+        <div class="col-md-4">
+            <label class="form-label"><?= __d('file_storage', 'Model') ?></label>
+            <?= $this->Form->control('model', [
+                'type' => 'select',
+                'options' => array_combine($models, $models),
+                'empty' => __d('file_storage', '— all —'),
+                'value' => $previewModel,
+                'label' => false,
+                'class' => 'form-select',
+            ]) ?>
+        </div>
+        <div class="col-md-4">
+            <label class="form-label"><?= __d('file_storage', 'Collection') ?></label>
+            <?= $this->Form->control('collection', [
+                'type' => 'text',
+                'value' => $previewCollection,
+                'label' => false,
+                'class' => 'form-control',
+                'placeholder' => __d('file_storage', '(leave empty for all)'),
+            ]) ?>
+        </div>
+        <div class="col-md-4">
+            <button type="submit" class="btn btn-primary">
+                <i class="fas fa-search me-1"></i><?= __d('file_storage', 'Preview (dry-run)') ?>
+            </button>
+        </div>
+        <?= $this->Form->end() ?>
+    </div>
+</div>
+
+<?php if ($report instanceof CleanupReport): ?>
+    <div class="card mb-4">
+        <div class="card-header d-flex justify-content-between align-items-center">
+            <span><i class="fas fa-clipboard-list me-2"></i><?= __d('file_storage', 'Dry-run report') ?></span>
+            <small class="text-muted"><?= __d('file_storage', 'Checked {0} rows', number_format($report->checkedCount)) ?></small>
+        </div>
+        <div class="card-body">
+            <ul class="list-group mb-3">
+                <li class="list-group-item d-flex justify-content-between align-items-center">
+                    <span><i class="fas fa-unlink me-2 text-warning"></i><?= __d('file_storage', 'Orphan rows (would delete)') ?></span>
+                    <span class="badge bg-warning text-dark"><?= number_format($report->deletedRows) ?></span>
+                </li>
+                <li class="list-group-item d-flex justify-content-between align-items-center">
+                    <span><i class="fas fa-trash me-2 text-danger"></i><?= __d('file_storage', 'Orphan files on disk (would delete)') ?></span>
+                    <span class="badge bg-danger"><?= number_format(count($report->deletedFiles)) ?></span>
+                </li>
+                <li class="list-group-item d-flex justify-content-between align-items-center">
+                    <span><i class="fas fa-question-circle me-2 text-info"></i><?= __d('file_storage', 'Rows with missing backing files') ?></span>
+                    <span class="badge bg-info text-dark"><?= number_format(count($report->missingFiles)) ?></span>
+                </li>
+            </ul>
+
+            <?php if ($report->warnings): ?>
+                <div class="alert alert-warning">
+                    <i class="fas fa-exclamation-triangle me-2"></i>
+                    <ul class="mb-0">
+                        <?php foreach ($report->warnings as $warning): ?>
+                            <li><?= h($warning) ?></li>
+                        <?php endforeach; ?>
+                    </ul>
+                </div>
+            <?php endif; ?>
+
+            <?php if ($report->deletedFiles): ?>
+                <details class="mb-3">
+                    <summary><?= __d('file_storage', 'Show {0} orphan file paths', count($report->deletedFiles)) ?></summary>
+                    <pre class="small mb-0"><?php foreach ($report->deletedFiles as $path) {
+                        echo h($path) . "\n";
+                    } ?></pre>
+                </details>
+            <?php endif; ?>
+
+            <?php if ($report->missingFiles): ?>
+                <details class="mb-3">
+                    <summary><?= __d('file_storage', 'Show {0} rows with missing files', count($report->missingFiles)) ?></summary>
+                    <table class="table table-sm">
+                        <thead><tr><th><?= __d('file_storage', 'Row id') ?></th><th><?= __d('file_storage', 'Missing variants') ?></th></tr></thead>
+                        <tbody>
+                            <?php foreach ($report->missingFiles as $row): ?>
+                                <tr>
+                                    <td><?= h($row['id']) ?></td>
+                                    <td><?= h(implode(', ', $row['missing'])) ?></td>
+                                </tr>
+                            <?php endforeach; ?>
+                        </tbody>
+                    </table>
+                </details>
+            <?php endif; ?>
+
+            <?php if ($report->deletedRows > 0 || $report->deletedFiles): ?>
+                <?= $this->Form->postButton(
+                    '<i class="fas fa-trash me-1"></i>' . __d('file_storage', 'Run cleanup now'),
+                    ['action' => 'cleanup'],
+                    [
+                        'data' => ['model' => $previewModel, 'collection' => $previewCollection],
+                        'class' => 'btn btn-danger',
+                        'escapeTitle' => false,
+                        'form' => [
+                            'data-confirm-message' => __d('file_storage', 'Sure? This permanently deletes the orphan rows and files listed above.'),
+                        ],
+                    ],
+                ) ?>
+            <?php else: ?>
+                <div class="alert alert-success mb-0">
+                    <i class="fas fa-check-circle me-2"></i><?= __d('file_storage', 'Nothing to clean up — storage is in sync.') ?>
+                </div>
+            <?php endif; ?>
+        </div>
+    </div>
+<?php endif; ?>

--- a/templates/Admin/FileStorage/index.php
+++ b/templates/Admin/FileStorage/index.php
@@ -1,83 +1,127 @@
 <?php
 /**
- * @var \App\View\AppView $this
- * @var \Cake\Datasource\EntityInterface[]|\Cake\Collection\CollectionInterface $fileStorage
+ * @var \Cake\View\View $this
+ * @var \Cake\Datasource\ResultSetInterface<\FileStorage\Model\Entity\FileStorage> $fileStorage
+ * @var bool $queueLoaded
  */
+
 use Cake\Core\Plugin;
 
+$this->assign('title', __d('file_storage', 'Files'));
 $cspNonce = (string)$this->getRequest()->getAttribute('cspNonce', '');
 ?>
-<nav class="actions large-3 medium-4 columns col-sm-4 col-xs-12" id="actions-sidebar">
-    <ul class="side-nav nav nav-pills flex-column">
-        <li class="nav-item heading"><?= __('Actions') ?></li>
-        <li class="nav-item">
-            <?= $this->Html->link(__('New {0}', __('File Storage')), ['action' => 'add'], ['class' => 'nav-link']) ?>
-        </li>
-    </ul>
-</nav>
-<div class="fileStorage index content large-9 medium-8 columns col-sm-8 col-12">
+<h1 class="h3 mb-3 d-flex justify-content-between align-items-center">
+    <span><i class="fas fa-file me-2 text-primary"></i><?= __d('file_storage', 'Files') ?></span>
+</h1>
 
-    <h2><?= __('File Storage') ?></h2>
-
-    <div class="">
-        <table class="table table-sm table-striped">
-            <thead>
-                <tr>
-                    <th><?= $this->Paginator->sort('model') ?></th>
-                    <th><?= $this->Paginator->sort('collection') ?></th>
-                    <th><?= $this->Paginator->sort('filename') ?></th>
-                    <th><?= $this->Paginator->sort('filesize') ?></th>
-                    <th><?= $this->Paginator->sort('mime_type') ?></th>
-                    <th><?= $this->Paginator->sort('created', null, ['direction' => 'desc']) ?></th>
-                    <th><?= $this->Paginator->sort('modified', null, ['direction' => 'desc']) ?></th>
-                    <th class="actions"><?= __('Actions') ?></th>
-                </tr>
-            </thead>
-            <tbody>
-                <?php foreach ($fileStorage as $fileStorage) { ?>
-                <tr>
-                    <td><?= h($fileStorage->model) ?>:<?= $this->Number->format($fileStorage->foreign_key) ?></td>
-                    <td><?= h($fileStorage->collection) ?></td>
-                    <td>
-                        <?= h($fileStorage->filename) ?>
-                        <div><small><?= h($fileStorage->path) ?></small></div>
-                    </td>
-                    <td>
-                        <?= $this->Number->toReadableSize($fileStorage->filesize) ?>
-                    </td>
-                    <td>
-                        <?= h($fileStorage->mime_type) ?>
-                        <div><small>Ext: <?= h($fileStorage->extension) ?></small></div>
-                    </td>
-                    <td><?= $this->Time->nice($fileStorage->created) ?></td>
-                    <td><?= $this->Time->nice($fileStorage->modified) ?></td>
-
-                    <td class="actions">
-                        <?= $this->Html->link(Plugin::isLoaded('Tools') ? $this->Icon->render('view') : __('View'), ['action' => 'view', $fileStorage->id], ['escapeTitle' => false]); ?>
-                        <?= $this->Html->link(Plugin::isLoaded('Tools') ? $this->Icon->render('edit') : __('Edit'), ['action' => 'edit', $fileStorage->id], ['escapeTitle' => false]); ?>
-                        <?= $this->Form->postButton(Plugin::isLoaded('Tools') ? $this->Icon->render('delete') : __('Delete'), ['action' => 'delete', $fileStorage->id], [
-                            'escapeTitle' => false,
-                            'class' => 'btn btn-link p-0 align-baseline',
-                            'form' => [
-                                'class' => 'd-inline',
-                                'data-confirm-message' => __('Are you sure you want to delete # {0}?', $fileStorage->id),
-                            ],
-                        ]); ?>
-                    </td>
-                </tr>
-                <?php } ?>
-            </tbody>
-        </table>
+<?= $this->Form->create(null, [
+    'url' => ['action' => 'deleteBulk'],
+    'class' => 'mb-0',
+    'data-confirm-message' => __d('file_storage', 'Delete the selected file storage entries? This cannot be undone.'),
+]) ?>
+<div class="card mb-3">
+    <div class="card-body p-2 d-flex gap-2 align-items-center flex-wrap">
+        <button type="submit" class="btn btn-sm btn-outline-danger">
+            <i class="fas fa-trash me-1"></i><?= __d('file_storage', 'Delete selected') ?>
+        </button>
+        <span class="text-muted small ms-auto">
+            <?= __d('file_storage', 'Tip: tick the header checkbox to select all rows on this page.') ?>
+        </span>
     </div>
-
-    <?php echo $this->element('Tools.pagination'); ?>
 </div>
-<script<?= $cspNonce !== '' ? ' nonce="' . h($cspNonce) . '"' : '' ?>>
-document.querySelectorAll('form[data-confirm-message]').forEach(function(form) {
-    form.addEventListener('submit', function(e) {
-        if (!confirm(this.dataset.confirmMessage)) {
-            e.preventDefault();
-        }
-    });
-});
-</script>
+
+<div class="fs-table table-responsive">
+    <table class="table table-sm table-striped mb-0">
+        <thead>
+            <tr>
+                <th class="text-center" style="width:40px;">
+                    <input type="checkbox" class="form-check-input" data-fs-checkall="#fs-files-table" aria-label="<?= h(__d('file_storage', 'Select all')) ?>">
+                </th>
+                <th><?= $this->Paginator->sort('model') ?></th>
+                <th><?= $this->Paginator->sort('collection') ?></th>
+                <th><?= $this->Paginator->sort('filename') ?></th>
+                <th><?= $this->Paginator->sort('filesize') ?></th>
+                <th><?= $this->Paginator->sort('mime_type') ?></th>
+                <th><?= $this->Paginator->sort('created', null, ['direction' => 'desc']) ?></th>
+                <th class="text-end"><?= __d('file_storage', 'Actions') ?></th>
+            </tr>
+        </thead>
+        <tbody id="fs-files-table">
+            <?php foreach ($fileStorage as $entry): ?>
+                <tr>
+                    <td class="text-center">
+                        <input type="checkbox" class="form-check-input" name="ids[]" value="<?= h($entry->id) ?>" aria-label="<?= h(__d('file_storage', 'Select row')) ?>">
+                    </td>
+                    <td><?= h($entry->model) ?>:<?= h((string)$entry->foreign_key) ?></td>
+                    <td><?= h($entry->collection) ?></td>
+                    <td>
+                        <?= h($entry->filename) ?>
+                        <div><small class="text-muted"><?= h($entry->path) ?></small></div>
+                    </td>
+                    <td><?= $this->Number->toReadableSize($entry->filesize) ?></td>
+                    <td>
+                        <?= h($entry->mime_type) ?>
+                        <div><small class="text-muted">Ext: <?= h($entry->extension) ?></small></div>
+                    </td>
+                    <td><?= h($entry->created?->format('Y-m-d H:i') ?? '') ?></td>
+                    <td class="text-end">
+                        <a class="btn btn-sm btn-outline-secondary" href="<?= $this->Url->build(['action' => 'view', $entry->id]) ?>" title="<?= h(__d('file_storage', 'View')) ?>">
+                            <i class="fas fa-eye"></i>
+                        </a>
+                        <a class="btn btn-sm btn-outline-secondary" href="<?= $this->Url->build(['action' => 'edit', $entry->id]) ?>" title="<?= h(__d('file_storage', 'Edit')) ?>">
+                            <i class="fas fa-pen"></i>
+                        </a>
+                        <?php if ($queueLoaded): ?>
+                            <?= $this->Form->postButton(
+                                '<i class="fas fa-sync"></i>',
+                                ['action' => 'regenerateVariants', $entry->id],
+                                [
+                                    'class' => 'btn btn-sm btn-outline-info',
+                                    'escapeTitle' => false,
+                                    'title' => __d('file_storage', 'Queue variant regeneration'),
+                                    'form' => [
+                                        'class' => 'd-inline',
+                                        'data-confirm-message' => __d('file_storage', 'Queue a variant regeneration job for {0}?', $entry->filename),
+                                    ],
+                                ],
+                            ) ?>
+                        <?php else: ?>
+                            <button type="button" class="btn btn-sm btn-outline-secondary" disabled
+                                data-bs-toggle="tooltip"
+                                title="<?= h(__d('file_storage', 'Install dereuromark/cakephp-queue to enable background variant regeneration.')) ?>">
+                                <i class="fas fa-sync"></i>
+                            </button>
+                        <?php endif; ?>
+                        <?= $this->Form->postButton(
+                            Plugin::isLoaded('Tools') ? $this->Icon->render('delete') : '<i class="fas fa-trash"></i>',
+                            ['action' => 'delete', $entry->id],
+                            [
+                                'class' => 'btn btn-sm btn-outline-danger',
+                                'escapeTitle' => false,
+                                'title' => __d('file_storage', 'Delete'),
+                                'form' => [
+                                    'class' => 'd-inline',
+                                    'data-confirm-message' => __d('file_storage', 'Delete {0}?', $entry->filename),
+                                ],
+                            ],
+                        ) ?>
+                    </td>
+                </tr>
+            <?php endforeach; ?>
+        </tbody>
+    </table>
+</div>
+<?= $this->Form->end() ?>
+
+<?php if (Plugin::isLoaded('Tools')) {
+    echo $this->element('Tools.pagination');
+} else { ?>
+    <nav class="mt-3">
+        <ul class="pagination">
+            <?= $this->Paginator->prev('« ' . __d('file_storage', 'previous')) ?>
+            <?= $this->Paginator->numbers() ?>
+            <?= $this->Paginator->next(__d('file_storage', 'next') . ' »') ?>
+        </ul>
+        <p><?= $this->Paginator->counter() ?></p>
+    </nav>
+<?php } ?>

--- a/templates/Admin/FileStorageDashboard/index.php
+++ b/templates/Admin/FileStorageDashboard/index.php
@@ -1,0 +1,194 @@
+<?php
+/**
+ * @var \Cake\View\View $this
+ * @var int $totalCount
+ * @var int|float $totalBytes
+ * @var int $orphanCount
+ * @var array<int, array{collection: string, count: int, bytes: int|float}> $byCollection
+ * @var array<int, array{model: string, count: int, bytes: int|float}> $byModel
+ * @var array<int, array{adapter: string, count: int}> $byAdapter
+ * @var array<int, \FileStorage\Model\Entity\FileStorage> $recent
+ * @var bool $queueLoaded
+ */
+
+$this->assign('title', __d('file_storage', 'Dashboard'));
+
+$humanBytes = function (int|float $bytes): string {
+    $units = ['B', 'KB', 'MB', 'GB', 'TB'];
+    $i = 0;
+    $bytes = (float)$bytes;
+    while ($bytes >= 1024 && $i < count($units) - 1) {
+        $bytes /= 1024;
+        $i++;
+    }
+
+    return number_format($bytes, $i === 0 ? 0 : 2) . ' ' . $units[$i];
+};
+?>
+<h1 class="h3 mb-4"><i class="fas fa-tachometer-alt me-2 text-primary"></i><?= __d('file_storage', 'FileStorage Dashboard') ?></h1>
+
+<div class="row g-3 mb-4">
+    <div class="col-md-3 col-sm-6">
+        <?= $this->element('FileStorage.FileStorage/stats_card', [
+            'title' => __d('file_storage', 'Total Files'),
+            'count' => number_format($totalCount),
+            'icon' => 'file',
+            'color' => 'primary',
+            'link' => $this->Url->build(['plugin' => 'FileStorage', 'prefix' => 'Admin', 'controller' => 'FileStorage', 'action' => 'index']),
+        ]) ?>
+    </div>
+    <div class="col-md-3 col-sm-6">
+        <?= $this->element('FileStorage.FileStorage/stats_card', [
+            'title' => __d('file_storage', 'Total Size'),
+            'count' => $humanBytes($totalBytes),
+            'icon' => 'database',
+            'color' => 'info',
+        ]) ?>
+    </div>
+    <div class="col-md-3 col-sm-6">
+        <?= $this->element('FileStorage.FileStorage/stats_card', [
+            'title' => __d('file_storage', 'Orphan Rows'),
+            'count' => number_format($orphanCount),
+            'icon' => 'unlink',
+            'color' => $orphanCount > 0 ? 'warning' : 'success',
+            'link' => $this->Url->build(['plugin' => 'FileStorage', 'prefix' => 'Admin', 'controller' => 'FileStorage', 'action' => 'cleanup']),
+        ]) ?>
+    </div>
+    <div class="col-md-3 col-sm-6">
+        <?= $this->element('FileStorage.FileStorage/stats_card', [
+            'title' => __d('file_storage', 'Adapters'),
+            'count' => count($byAdapter),
+            'icon' => 'plug',
+            'color' => 'secondary',
+        ]) ?>
+    </div>
+</div>
+
+<div class="row g-3">
+    <div class="col-lg-6">
+        <div class="card">
+            <div class="card-header"><i class="fas fa-folder me-2"></i><?= __d('file_storage', 'Top Collections') ?></div>
+            <div class="card-body p-0">
+                <table class="table table-sm mb-0">
+                    <thead>
+                        <tr>
+                            <th><?= __d('file_storage', 'Collection') ?></th>
+                            <th class="text-end"><?= __d('file_storage', 'Files') ?></th>
+                            <th class="text-end"><?= __d('file_storage', 'Size') ?></th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <?php foreach ($byCollection as $row): ?>
+                            <tr>
+                                <td><?= h($row['collection']) ?></td>
+                                <td class="text-end"><?= number_format((int)$row['count']) ?></td>
+                                <td class="text-end"><?= h($humanBytes((int)$row['bytes'])) ?></td>
+                            </tr>
+                        <?php endforeach; ?>
+                        <?php if (!$byCollection): ?>
+                            <tr><td colspan="3" class="text-center text-muted py-3"><?= __d('file_storage', 'No data.') ?></td></tr>
+                        <?php endif; ?>
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    </div>
+
+    <div class="col-lg-6">
+        <div class="card">
+            <div class="card-header"><i class="fas fa-cube me-2"></i><?= __d('file_storage', 'Top Models') ?></div>
+            <div class="card-body p-0">
+                <table class="table table-sm mb-0">
+                    <thead>
+                        <tr>
+                            <th><?= __d('file_storage', 'Model') ?></th>
+                            <th class="text-end"><?= __d('file_storage', 'Files') ?></th>
+                            <th class="text-end"><?= __d('file_storage', 'Size') ?></th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <?php foreach ($byModel as $row): ?>
+                            <tr>
+                                <td><?= h($row['model']) ?></td>
+                                <td class="text-end"><?= number_format((int)$row['count']) ?></td>
+                                <td class="text-end"><?= h($humanBytes((int)$row['bytes'])) ?></td>
+                            </tr>
+                        <?php endforeach; ?>
+                        <?php if (!$byModel): ?>
+                            <tr><td colspan="3" class="text-center text-muted py-3"><?= __d('file_storage', 'No data.') ?></td></tr>
+                        <?php endif; ?>
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    </div>
+
+    <div class="col-lg-6">
+        <div class="card">
+            <div class="card-header"><i class="fas fa-plug me-2"></i><?= __d('file_storage', 'Files by Adapter') ?></div>
+            <div class="card-body p-0">
+                <table class="table table-sm mb-0">
+                    <thead>
+                        <tr>
+                            <th><?= __d('file_storage', 'Adapter') ?></th>
+                            <th class="text-end"><?= __d('file_storage', 'Files') ?></th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <?php foreach ($byAdapter as $row): ?>
+                            <tr>
+                                <td><?= h($row['adapter']) ?></td>
+                                <td class="text-end"><?= number_format((int)$row['count']) ?></td>
+                            </tr>
+                        <?php endforeach; ?>
+                        <?php if (!$byAdapter): ?>
+                            <tr><td colspan="2" class="text-center text-muted py-3"><?= __d('file_storage', 'No data.') ?></td></tr>
+                        <?php endif; ?>
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    </div>
+
+    <div class="col-lg-6">
+        <div class="card">
+            <div class="card-header"><i class="fas fa-clock me-2"></i><?= __d('file_storage', 'Recent Uploads') ?></div>
+            <div class="card-body p-0">
+                <table class="table table-sm mb-0">
+                    <thead>
+                        <tr>
+                            <th><?= __d('file_storage', 'Filename') ?></th>
+                            <th><?= __d('file_storage', 'Collection') ?></th>
+                            <th><?= __d('file_storage', 'Created') ?></th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <?php foreach ($recent as $entry): ?>
+                            <tr>
+                                <td>
+                                    <?= $this->Html->link(
+                                        h($entry->filename),
+                                        ['plugin' => 'FileStorage', 'prefix' => 'Admin', 'controller' => 'FileStorage', 'action' => 'view', $entry->id],
+                                        ['escapeTitle' => false],
+                                    ) ?>
+                                </td>
+                                <td><?= h($entry->collection) ?></td>
+                                <td><?= h($entry->created?->format('Y-m-d H:i') ?? '') ?></td>
+                            </tr>
+                        <?php endforeach; ?>
+                        <?php if (!$recent): ?>
+                            <tr><td colspan="3" class="text-center text-muted py-3"><?= __d('file_storage', 'No uploads yet.') ?></td></tr>
+                        <?php endif; ?>
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    </div>
+</div>
+
+<?php if (!$queueLoaded): ?>
+    <div class="alert alert-info mt-4">
+        <i class="fas fa-info-circle me-2"></i>
+        <?= __d('file_storage', 'Install {0} to enable background image-variant regeneration from this UI.', '<code>dereuromark/cakephp-queue</code>') ?>
+    </div>
+<?php endif; ?>

--- a/templates/element/FileStorage/sidebar.php
+++ b/templates/element/FileStorage/sidebar.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * FileStorage Admin Sidebar Navigation
+ *
+ * @var \Cake\View\View $this
+ * @var bool $mobile When true, render without the position-fixed wrapper
+ *   (used inside the mobile offcanvas).
+ */
+
+use Cake\Core\Plugin;
+
+$mobile = !empty($mobile);
+$controller = $this->getRequest()->getParam('controller');
+$action = $this->getRequest()->getParam('action');
+
+$isActive = function (string $c, ?array $actions = null) use ($controller, $action): string {
+    if ($controller !== $c) {
+        return '';
+    }
+    if ($actions === null) {
+        return 'active';
+    }
+
+    return in_array($action, $actions, true) ? 'active' : '';
+};
+
+$queueLoaded = Plugin::isLoaded('Queue');
+?>
+<aside class="fs-sidebar <?= $mobile ? '' : 'd-none d-lg-block' ?>">
+    <div class="nav-section">
+        <div class="nav-section-title"><?= __d('file_storage', 'Navigation') ?></div>
+        <nav class="nav flex-column">
+            <a class="nav-link <?= $isActive('FileStorageDashboard') ?>" href="<?= $this->Url->build(['plugin' => 'FileStorage', 'prefix' => 'Admin', 'controller' => 'FileStorageDashboard', 'action' => 'index']) ?>">
+                <i class="fas fa-tachometer-alt"></i>
+                <?= __d('file_storage', 'Dashboard') ?>
+            </a>
+            <a class="nav-link <?= $isActive('FileStorage', ['index', 'view', 'edit']) ?>" href="<?= $this->Url->build(['plugin' => 'FileStorage', 'prefix' => 'Admin', 'controller' => 'FileStorage', 'action' => 'index']) ?>">
+                <i class="fas fa-file"></i>
+                <?= __d('file_storage', 'Files') ?>
+            </a>
+            <a class="nav-link <?= $isActive('FileStorage', ['cleanup']) ?>" href="<?= $this->Url->build(['plugin' => 'FileStorage', 'prefix' => 'Admin', 'controller' => 'FileStorage', 'action' => 'cleanup']) ?>">
+                <i class="fas fa-broom"></i>
+                <?= __d('file_storage', 'Cleanup') ?>
+            </a>
+        </nav>
+    </div>
+
+    <div class="nav-section">
+        <div class="nav-section-title"><?= __d('file_storage', 'Background Jobs') ?></div>
+        <nav class="nav flex-column">
+            <?php if ($queueLoaded): ?>
+                <a class="nav-link" href="<?= $this->Url->build(['plugin' => 'Queue', 'prefix' => 'Admin', 'controller' => 'Queue', 'action' => 'index']) ?>">
+                    <i class="fas fa-layer-group"></i>
+                    <?= __d('file_storage', 'Queue Admin') ?>
+                </a>
+            <?php else: ?>
+                <span class="nav-link disabled" data-bs-toggle="tooltip" title="<?= h(__d('file_storage', 'Install dereuromark/cakephp-queue to enable background variant regeneration.')) ?>">
+                    <i class="fas fa-layer-group"></i>
+                    <?= __d('file_storage', 'Queue (not loaded)') ?>
+                </span>
+            <?php endif; ?>
+        </nav>
+    </div>
+</aside>

--- a/templates/element/FileStorage/stats_card.php
+++ b/templates/element/FileStorage/stats_card.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * Stats card element.
+ *
+ * @var \Cake\View\View $this
+ * @var string $title Card label
+ * @var int|string $count Stat value
+ * @var string $icon Font Awesome icon (without `fa-` prefix)
+ * @var string $color Color variant (primary|success|warning|danger|info|secondary)
+ * @var string|null $link Optional link
+ */
+
+$color ??= 'primary';
+$link ??= null;
+
+$colorClasses = [
+    'primary' => ['bg' => 'bg-primary bg-opacity-10', 'text' => 'text-primary'],
+    'success' => ['bg' => 'bg-success bg-opacity-10', 'text' => 'text-success'],
+    'warning' => ['bg' => 'bg-warning bg-opacity-10', 'text' => 'text-warning'],
+    'danger' => ['bg' => 'bg-danger bg-opacity-10', 'text' => 'text-danger'],
+    'info' => ['bg' => 'bg-info bg-opacity-10', 'text' => 'text-info'],
+    'secondary' => ['bg' => 'bg-secondary bg-opacity-10', 'text' => 'text-secondary'],
+];
+$classes = $colorClasses[$color] ?? $colorClasses['primary'];
+?>
+<div class="card stats-card h-100">
+    <?php if ($link): ?>
+        <a href="<?= h($link) ?>" class="text-decoration-none">
+    <?php endif; ?>
+    <div class="card-body">
+        <div class="d-flex align-items-center">
+            <div class="stats-icon <?= $classes['bg'] ?> <?= $classes['text'] ?>">
+                <i class="fas fa-<?= h($icon) ?>"></i>
+            </div>
+            <div class="ms-3">
+                <div class="stats-value <?= $classes['text'] ?>"><?= h($count) ?></div>
+                <div class="stats-label"><?= h($title) ?></div>
+            </div>
+        </div>
+    </div>
+    <?php if ($link): ?>
+        </a>
+    <?php endif; ?>
+</div>

--- a/templates/element/flash/flash.php
+++ b/templates/element/flash/flash.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * Standalone flash message element for the FileStorage admin layout.
+ *
+ * Reads `Flash.flash` directly from the session so the rendering does not
+ * depend on the host application's flash element styling.
+ *
+ * @var \Cake\View\View $this
+ */
+
+$flashMessages = $this->getRequest()->getSession()->consume('Flash.flash');
+if (!$flashMessages) {
+    return;
+}
+
+foreach ($flashMessages as $flash) {
+    $element = $flash['element'] ?? 'flash/default';
+    $alertClass = match ($element) {
+        'flash/success' => 'alert-success',
+        'flash/error' => 'alert-danger',
+        'flash/warning' => 'alert-warning',
+        default => 'alert-info',
+    };
+    $icon = match ($element) {
+        'flash/success' => 'fa-check-circle',
+        'flash/error' => 'fa-exclamation-circle',
+        'flash/warning' => 'fa-exclamation-triangle',
+        default => 'fa-info-circle',
+    };
+    ?>
+    <div class="alert <?= $alertClass ?> alert-dismissible fade show" role="alert">
+        <i class="fas <?= $icon ?> me-2"></i>
+        <?= h($flash['message']) ?>
+        <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+    </div>
+    <?php
+}

--- a/templates/layout/file_storage.php
+++ b/templates/layout/file_storage.php
@@ -1,0 +1,242 @@
+<?php
+/**
+ * FileStorage Admin Layout
+ *
+ * Self-contained admin layout using Bootstrap 5 and Font Awesome 6 via CDN.
+ * CSP-safe: all inline scripts use the request's `cspNonce` attribute.
+ *
+ * @var \Cake\View\View $this
+ */
+?>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title><?= $this->fetch('title') ? strip_tags($this->fetch('title')) . ' - ' : '' ?>FileStorage Admin</title>
+
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH" crossorigin="anonymous">
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.7.2/css/all.min.css" rel="stylesheet" integrity="sha512-Evv84Mr4kqVGRNSgIGL/F/aIDqQb7xQ2vcrdIwxfjThSH8CSR7PBEakCr51Ck+w+/U6swU2Im1vVX0SVk9ABhg==" crossorigin="anonymous">
+    <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.7/dist/chart.umd.min.js"></script>
+
+    <style>
+        :root {
+            --fs-primary: #0d6efd;
+            --fs-success: #198754;
+            --fs-warning: #ffc107;
+            --fs-danger: #dc3545;
+            --fs-info: #0dcaf0;
+            --fs-secondary: #6c757d;
+            --fs-dark: #212529;
+            --fs-light: #f8f9fa;
+            --fs-sidebar-bg: linear-gradient(135deg, #2c3e50 0%, #1a252f 100%);
+            --fs-sidebar-width: 260px;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            background-color: #f4f6f9;
+            min-height: 100vh;
+        }
+
+        .fs-navbar {
+            background: var(--fs-dark);
+            box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+        }
+        .fs-navbar .navbar-brand { font-weight: 600; color: #fff; }
+        .fs-navbar .navbar-brand i { color: var(--fs-primary); }
+
+        .fs-sidebar {
+            background: var(--fs-sidebar-bg);
+            min-height: calc(100vh - 56px);
+            width: var(--fs-sidebar-width);
+            position: fixed;
+            left: 0;
+            top: 56px;
+            padding: 1.5rem 0;
+            overflow-y: auto;
+        }
+        .fs-sidebar .nav-section { padding: 0 1rem; margin-bottom: 1.5rem; }
+        .fs-sidebar .nav-section-title {
+            color: rgba(255,255,255,0.5);
+            font-size: 0.75rem;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            padding: 0 0.75rem;
+            margin-bottom: 0.5rem;
+        }
+        .fs-sidebar .nav-link {
+            color: rgba(255,255,255,0.8);
+            padding: 0.6rem 0.75rem;
+            border-radius: 0.375rem;
+            margin-bottom: 0.25rem;
+            transition: all 0.2s ease;
+        }
+        .fs-sidebar .nav-link:hover { color: #fff; background: rgba(255,255,255,0.1); }
+        .fs-sidebar .nav-link.active { color: #fff; background: var(--fs-primary); }
+        .fs-sidebar .nav-link.disabled { color: rgba(255,255,255,0.35); cursor: not-allowed; }
+        .fs-sidebar .nav-link i { width: 1.25rem; margin-right: 0.5rem; }
+
+        .fs-mobile-nav-bg { background: var(--fs-sidebar-bg); }
+
+        .fs-main {
+            margin-left: var(--fs-sidebar-width);
+            padding: 1.5rem;
+            min-height: calc(100vh - 56px);
+        }
+
+        .stats-card {
+            border: none;
+            border-radius: 0.5rem;
+            box-shadow: 0 2px 4px rgba(0,0,0,0.05);
+            transition: transform 0.2s ease, box-shadow 0.2s ease;
+            overflow: hidden;
+        }
+        .stats-card:hover { transform: translateY(-2px); box-shadow: 0 4px 12px rgba(0,0,0,0.1); }
+        .stats-card .card-body { padding: 1.25rem; }
+        .stats-card .stats-icon {
+            width: 48px;
+            height: 48px;
+            border-radius: 0.5rem;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            font-size: 1.25rem;
+        }
+        .stats-card .stats-value { font-size: 1.75rem; font-weight: 700; line-height: 1.2; }
+        .stats-card .stats-label { color: var(--fs-secondary); font-size: 0.875rem; }
+
+        .fs-table {
+            background: #fff;
+            border-radius: 0.5rem;
+            overflow: hidden;
+            box-shadow: 0 2px 4px rgba(0,0,0,0.05);
+        }
+        .fs-table thead th {
+            background: var(--fs-light);
+            border-bottom: 2px solid #dee2e6;
+            font-weight: 600;
+            font-size: 0.875rem;
+            text-transform: uppercase;
+            letter-spacing: 0.025em;
+            color: var(--fs-secondary);
+        }
+        .fs-table tbody tr:hover { background-color: rgba(13, 110, 253, 0.04); }
+
+        .card { border: none; box-shadow: 0 2px 4px rgba(0,0,0,0.05); border-radius: 0.5rem; }
+        .card-header { background: var(--fs-light); border-bottom: 1px solid #dee2e6; font-weight: 600; }
+
+        .fs-footer {
+            margin-left: var(--fs-sidebar-width);
+            padding: 1rem 1.5rem;
+            background: #fff;
+            border-top: 1px solid #dee2e6;
+            color: var(--fs-secondary);
+            font-size: 0.875rem;
+        }
+
+        @media (max-width: 991.98px) {
+            .fs-sidebar { position: relative; width: 100%; min-height: auto; top: 0; }
+            .fs-main { margin-left: 0; }
+            .fs-footer { margin-left: 0; }
+        }
+    </style>
+
+    <?= $this->fetch('meta') ?>
+    <?= $this->fetch('css') ?>
+</head>
+<body>
+    <nav class="navbar navbar-expand-lg navbar-dark fs-navbar">
+        <div class="container-fluid">
+            <a class="navbar-brand" href="<?= $this->Url->build(['plugin' => 'FileStorage', 'prefix' => 'Admin', 'controller' => 'FileStorageDashboard', 'action' => 'index']) ?>">
+                <i class="fas fa-folder-open me-2"></i>FileStorage Admin
+            </a>
+            <button class="navbar-toggler" type="button" data-bs-toggle="offcanvas" data-bs-target="#mobileNav" aria-controls="mobileNav" aria-label="Toggle navigation">
+                <span class="navbar-toggler-icon"></span>
+            </button>
+            <div class="collapse navbar-collapse">
+                <ul class="navbar-nav ms-auto">
+                    <?php if (\Cake\Core\Plugin::isLoaded('Queue')): ?>
+                    <li class="nav-item">
+                        <a class="nav-link" href="<?= $this->Url->build(['plugin' => 'Queue', 'prefix' => 'Admin', 'controller' => 'Queue', 'action' => 'index']) ?>">
+                            <i class="fas fa-layer-group me-1"></i>Queue
+                        </a>
+                    </li>
+                    <?php endif; ?>
+                    <li class="nav-item">
+                        <span class="nav-link text-light">
+                            <i class="far fa-clock me-1"></i><?= date('Y-m-d H:i:s') ?>
+                        </span>
+                    </li>
+                </ul>
+            </div>
+        </div>
+    </nav>
+
+    <div class="offcanvas offcanvas-start fs-mobile-nav-bg" tabindex="-1" id="mobileNav" aria-labelledby="mobileNavLabel">
+        <div class="offcanvas-header border-bottom border-secondary">
+            <h5 class="offcanvas-title text-white" id="mobileNavLabel">
+                <i class="fas fa-folder-open me-2"></i>FileStorage Admin
+            </h5>
+            <button type="button" class="btn-close btn-close-white" data-bs-dismiss="offcanvas" aria-label="Close"></button>
+        </div>
+        <div class="offcanvas-body p-0">
+            <?= $this->element('FileStorage.FileStorage/sidebar', ['mobile' => true]) ?>
+        </div>
+    </div>
+
+    <div class="d-flex">
+        <?= $this->element('FileStorage.FileStorage/sidebar') ?>
+
+        <main class="fs-main flex-grow-1">
+            <div class="fs-flash">
+                <?= $this->element('FileStorage.flash/flash') ?>
+            </div>
+
+            <?= $this->fetch('content') ?>
+        </main>
+    </div>
+
+    <footer class="fs-footer">
+        <div class="d-flex justify-content-between align-items-center">
+            <span>FileStorage Plugin for CakePHP</span>
+            <span><i class="fas fa-server me-1"></i>PHP <?= phpversion() ?></span>
+        </div>
+    </footer>
+
+    <?= $this->fetch('postLink') ?>
+
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-YvpcrYf0tY3lHB60NNkmXc5s9fDVZLESaAA55NDzOxhy9GkcIdslK1eN7N6jIeHz" crossorigin="anonymous"></script>
+
+    <?php $cspNonce = (string)$this->getRequest()->getAttribute('cspNonce', ''); ?>
+    <script<?= $cspNonce !== '' ? ' nonce="' . h($cspNonce) . '"' : '' ?>>
+        document.addEventListener('DOMContentLoaded', function () {
+            // Bootstrap tooltips
+            document.querySelectorAll('[data-bs-toggle="tooltip"]').forEach(function (el) {
+                new bootstrap.Tooltip(el);
+            });
+
+            // Submit-confirm dialogs (CSP-safe: replaces inline confirm() bound via postLink)
+            document.querySelectorAll('form[data-confirm-message]').forEach(function (form) {
+                form.addEventListener('submit', function (e) {
+                    if (!confirm(this.dataset.confirmMessage)) {
+                        e.preventDefault();
+                    }
+                });
+            });
+
+            // Bulk-action master checkbox
+            document.querySelectorAll('[data-fs-checkall]').forEach(function (master) {
+                master.addEventListener('change', function () {
+                    var scope = document.querySelector(this.dataset.fsCheckall) || document;
+                    scope.querySelectorAll('input[type=checkbox][name="ids[]"]').forEach(function (cb) {
+                        cb.checked = master.checked;
+                    });
+                });
+            });
+        });
+    </script>
+
+    <?= $this->fetch('script') ?>
+</body>
+</html>

--- a/tests/TestCase/Command/CleanupCommandTest.php
+++ b/tests/TestCase/Command/CleanupCommandTest.php
@@ -20,6 +20,7 @@ class CleanupCommandTest extends TestCase
         $this->exec('file_storage cleanup -d');
 
         $this->assertExitCode(0);
-        $this->assertOutputContains('0 orphaned images found.');
+        $this->assertOutputContains('Checking 0 file storage rows');
+        $this->assertOutputContains('0 orphan row(s) would be deleted.');
     }
 }

--- a/tests/TestCase/Controller/Admin/FileStorageControllerTest.php
+++ b/tests/TestCase/Controller/Admin/FileStorageControllerTest.php
@@ -3,10 +3,12 @@
 namespace FileStorage\Test\TestCase\Controller\Admin;
 
 use Cake\Core\Configure;
+use Cake\Http\Exception\BadRequestException;
 use Cake\Http\Exception\ForbiddenException;
 use Cake\Http\ServerRequest;
 use Cake\TestSuite\IntegrationTestTrait;
 use Cake\TestSuite\TestCase;
+use FileStorage\Service\CleanupReport;
 
 /**
  * @uses \FileStorage\Controller\Admin\FileStorageController
@@ -181,5 +183,77 @@ class FileStorageControllerTest extends TestCase
         $this->expectException(ForbiddenException::class);
 
         $this->post(['controller' => 'FileStorage', 'action' => 'delete', 1, 'prefix' => 'Admin', 'plugin' => 'FileStorage']);
+    }
+
+    /**
+     * @return void
+     */
+    public function testDeleteBulk(): void
+    {
+        $this->enableRetainFlashMessages();
+
+        $this->post(
+            ['controller' => 'FileStorage', 'action' => 'deleteBulk', 'prefix' => 'Admin', 'plugin' => 'FileStorage'],
+            ['ids' => [1, 2]],
+        );
+
+        $this->assertRedirect(['controller' => 'FileStorage', 'action' => 'index', 'prefix' => 'Admin', 'plugin' => 'FileStorage']);
+        $this->assertFlashMessage('2 file storage entries deleted.');
+    }
+
+    /**
+     * @return void
+     */
+    public function testDeleteBulkNothingSelected(): void
+    {
+        $this->enableRetainFlashMessages();
+
+        $this->post(
+            ['controller' => 'FileStorage', 'action' => 'deleteBulk', 'prefix' => 'Admin', 'plugin' => 'FileStorage'],
+            ['ids' => []],
+        );
+
+        $this->assertRedirect();
+        $this->assertFlashMessage('No file storage entries selected.');
+    }
+
+    /**
+     * @return void
+     */
+    public function testCleanupGetWithoutPreview(): void
+    {
+        $this->get(['controller' => 'FileStorage', 'action' => 'cleanup', 'prefix' => 'Admin', 'plugin' => 'FileStorage']);
+
+        $this->assertResponseOk();
+        $this->assertNull($this->viewVariable('report'));
+    }
+
+    /**
+     * @return void
+     */
+    public function testCleanupGetWithPreview(): void
+    {
+        $this->get([
+            'controller' => 'FileStorage',
+            'action' => 'cleanup',
+            'prefix' => 'Admin',
+            'plugin' => 'FileStorage',
+            '?' => ['model' => 'Item'],
+        ]);
+
+        $this->assertResponseOk();
+        $report = $this->viewVariable('report');
+        $this->assertInstanceOf(CleanupReport::class, $report);
+        $this->assertTrue($report->dryRun);
+    }
+
+    /**
+     * @return void
+     */
+    public function testRegenerateVariantsRejectsWithoutQueuePlugin(): void
+    {
+        $this->expectException(BadRequestException::class);
+
+        $this->post(['controller' => 'FileStorage', 'action' => 'regenerateVariants', 1, 'prefix' => 'Admin', 'plugin' => 'FileStorage']);
     }
 }

--- a/tests/TestCase/Controller/Admin/FileStorageDashboardControllerTest.php
+++ b/tests/TestCase/Controller/Admin/FileStorageDashboardControllerTest.php
@@ -1,0 +1,69 @@
+<?php declare(strict_types=1);
+
+namespace FileStorage\Test\TestCase\Controller\Admin;
+
+use Cake\Core\Configure;
+use Cake\Http\Exception\ForbiddenException;
+use Cake\TestSuite\IntegrationTestTrait;
+use Cake\TestSuite\TestCase;
+
+/**
+ * @uses \FileStorage\Controller\Admin\FileStorageDashboardController
+ */
+class FileStorageDashboardControllerTest extends TestCase
+{
+    use IntegrationTestTrait;
+
+    /**
+     * @var array<string>
+     */
+    protected array $fixtures = [
+        'plugin.FileStorage.FileStorage',
+    ];
+
+    /**
+     * @return void
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->disableErrorHandlerMiddleware();
+        Configure::write('FileStorage.adminAccess', true);
+    }
+
+    /**
+     * @return void
+     */
+    protected function tearDown(): void
+    {
+        Configure::delete('FileStorage.adminAccess');
+        parent::tearDown();
+    }
+
+    /**
+     * @return void
+     */
+    public function testIndexRendersStats(): void
+    {
+        $this->get(['controller' => 'FileStorageDashboard', 'action' => 'index', 'prefix' => 'Admin', 'plugin' => 'FileStorage']);
+
+        $this->assertResponseOk();
+        $this->assertSame(4, $this->viewVariable('totalCount'));
+        $this->assertNotNull($this->viewVariable('byCollection'));
+        $this->assertNotNull($this->viewVariable('byModel'));
+        $this->assertNotNull($this->viewVariable('byAdapter'));
+        $this->assertNotNull($this->viewVariable('recent'));
+    }
+
+    /**
+     * @return void
+     */
+    public function testIndexForbiddenWhenAdminAccessUnset(): void
+    {
+        Configure::delete('FileStorage.adminAccess');
+
+        $this->expectException(ForbiddenException::class);
+
+        $this->get(['controller' => 'FileStorageDashboard', 'action' => 'index', 'prefix' => 'Admin', 'plugin' => 'FileStorage']);
+    }
+}


### PR DESCRIPTION
## Summary

Builds out the FileStorage admin UI from a single `Admin/FileStorageController` into a proper standalone backend, mirroring the pattern already used by `cakephp-queue` and `cakephp-tags`. Five-step PR per the deep-dive — kept together because each step builds on the previous and splitting would mostly produce churn.

## Steps

### 1 — Scaffold

- New `Admin/FileStorageAppController` hosts the existing `FileStorage.adminAccess` gate plus two new switches:
  - `FileStorage.standalone` *(bool, default false)* — skips the host's `AppController::initialize()` chain for projects without their own admin shell.
  - `FileStorage.adminLayout` *(null|false|string, default null)* — `null` uses the bundled `FileStorage.file_storage` layout; `false` falls back to the host's default; string sets a custom one.
- The gate moves UP from `FileStorageController` into the new base, so the dashboard inherits it for free. Closure exceptions are now logged + converted to a generic 403 (no internal-error leakage).
- Bundled Bootstrap 5 + Font Awesome 6 + Chart.js layout, CSP-nonce-safe inline scripts, mobile offcanvas, sidebar element. **CDN with SRI** — no webroot bundling, no JS toolchain.
- New `LoadHelperTrait` soft-loads Tools/Templating helpers when those plugins are present.

### 2 — Dashboard

- New `Admin/FileStorageDashboardController::index()` with stats cards (total files, total bytes, orphan rows, adapter count) and four side-by-side tables: top collections, top models, files by adapter, recent uploads. Pure aggregation queries.
- Plugin route `/admin/file-storage` now lands on the dashboard; `/admin/file-storage/files` is the file listing.

### 3 — Bulk delete on listing

- Master + per-row checkboxes on the index template.
- New `FileStorageController::deleteBulk()` action with summary flash (deleted vs failed).
- CSP-safe: vanilla JS, single confirm-handler pattern lifted from queue.

### 4 — Cleanup service + UI

- New `Service\CleanupService` owns the cleanup logic; the existing `file_storage cleanup` CLI command now delegates to it.
- New `FileStorageController::cleanup()` admin action: GET + `?model=X` shows a dry-run preview (orphan rows, orphan files on disk, missing backing files); POST actually runs it. The dry-run / confirm flow uses a single service so the CLI and UI report the same numbers.

### 5 — Variant regeneration UI (gated on Queue)

- Per-row regenerate button. **Enabled** when `Plugin::isLoaded('Queue')` returns true: enqueues a `Queue.Execute` job that runs the existing `file_storage generate_image_variant` command on a worker. **Disabled** otherwise: rendered with a tooltip pointing at `dereuromark/cakephp-queue`.
- The action itself returns `400 Bad Request` when Queue isn't loaded so the runtime check stays in sync with the UI's disabled state.
- No custom queue task class shipped — uses Queue's bundled `Execute` task to avoid a hard compile-time dependency. `cakephp-queue` is added as `require-dev` (so phpstan can validate the dispatch) and `suggest` (so `composer require` advertises it). The runtime works with or without it.

## Routing additions

```
/admin/file-storage           → dashboard
/admin/file-storage/dashboard → dashboard
/admin/file-storage/files     → file listing
```
Plus all existing fallbacks. No routes removed.

## BC notes

- The default `adminLayout = null` means the bundled Bootstrap 5 layout is used **by default**. Consumers who want to keep rendering inside their own admin shell should set `'FileStorage.adminLayout' => false` in their FileStorage config block. (Routes themselves are untouched except for the new dashboard at the plugin root.)
- The plugin's CLI `file_storage cleanup` output format changed slightly because the command now delegates to `CleanupService` — `CleanupCommandTest` updated to match.

## Verification

- `vendor/bin/phpunit` — 86 tests, 221 assertions, all green.
- `vendor/bin/phpstan analyze` — clean.
- `vendor/bin/phpcs` — clean.
