### PR TITLE
docs: cover upload validation rules and admin backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,19 @@ The whole plugin is build with clear [Separation of Concerns (SoC)](https://en.w
 
 You associate the `file_storage` table with your model using the FileStorage model from the plugin via hasOne, hasMany or HABTM. When you upload a file you save it to the FileStorage model through the associations, `Documents.file` for example. The FileStorage model dispatches then file storage specific events, the listeners listening to these events process the file and put it in the configured storage backend using adapters for different backends and build the storage path using a path builder class.
 
+## Admin backend
+
+The plugin ships a self-contained admin backend at `/admin/file-storage`
+(dashboard, file listing with bulk delete, storage cleanup UI). It is
+**fail-closed by default** — set `FileStorage.adminAccess` (`true` or a
+`Closure(\Cake\Http\ServerRequest): bool`) to opt in. The bundled
+Bootstrap 5 layout can be replaced with your host app's layout via
+`FileStorage.adminLayout`. See [docs/Documentation/Installation.md](docs/Documentation/Installation.md#the-admin-backend).
+
+For background image-variant regeneration from the admin UI, install
+[`dereuromark/cakephp-queue`](https://github.com/dereuromark/cakephp-queue);
+without it the regenerate buttons render disabled.
+
 ## Documentation
 
 For documentation, as well as tutorials, see the [docs](docs/) directory of this repository.

--- a/docs/Documentation/Validation.md
+++ b/docs/Documentation/Validation.md
@@ -66,6 +66,58 @@ class ImageValidator implements UploadValidatorInterface
 }
 ```
 
+## Available Upload Validation Rules
+
+The `UploadValidationTrait` provides the following validation methods. They all accept either a PSR-7 `UploadedFileInterface` or the legacy `$_FILES`-style array (`['tmp_name' => …, 'name' => …, 'type' => …, 'size' => …, 'error' => …]`).
+
+### File-error checks
+
+| Rule                        | Purpose                                                                                |
+|-----------------------------|----------------------------------------------------------------------------------------|
+| `isUnderPhpSizeLimit`       | False when the upload hit PHP's `upload_max_filesize` (`UPLOAD_ERR_INI_SIZE`).         |
+| `isUnderFormSizeLimit`      | False when the upload hit the HTML form's `MAX_FILE_SIZE` (`UPLOAD_ERR_FORM_SIZE`).    |
+| `isCompletedUpload`         | False when the upload was truncated (`UPLOAD_ERR_PARTIAL`).                            |
+| `isFileUpload`              | False when no file was supplied (`UPLOAD_ERR_NO_FILE`).                                |
+| `isSuccessfulWrite`         | False when the temp file could not be written (`UPLOAD_ERR_CANT_WRITE`).               |
+
+### Size checks
+
+| Rule                         | Purpose                              |
+|------------------------------|--------------------------------------|
+| `isAboveMinSize($check, $size)` | True when uploaded size ≥ `$size` bytes. |
+| `isBelowMaxSize($check, $size)` | True when uploaded size ≤ `$size` bytes. |
+
+### Allow-list checks (recommended for any upload that is not strictly an image)
+
+The client-supplied `name` / `type` (`Content-Type`) headers are **not trustworthy** — a request can claim `image/jpeg` while delivering a `.php` shell. The MIME helper sniffs server-side via `finfo` against the actual file contents by default, so callers get the value PHP detects, not what the user told it to.
+
+```php
+// Restrict by extension (case-insensitive, leading dot tolerant).
+$validator->add('file', 'fileExtensionAllowed', [
+    'rule' => ['hasAllowedExtension', ['jpg', 'jpeg', 'png', 'webp']],
+    'message' => 'Only JPEG, PNG, or WebP images are allowed.',
+    'provider' => 'upload',
+]);
+
+// Restrict by sniffed MIME type (DEFAULT). Sniffs the actual file contents.
+$validator->add('file', 'fileMimeAllowed', [
+    'rule' => ['hasAllowedMimeType', ['image/jpeg', 'image/png', 'image/webp']],
+    'message' => 'File contents must be a JPEG, PNG, or WebP image.',
+    'provider' => 'upload',
+]);
+
+// Same, but trust the client header instead of sniffing. Only safe inside
+// trusted code paths (tests, internal-only forms). Disable sniff with a `false`
+// third argument:
+$validator->add('file', 'fileMimeAllowedClient', [
+    'rule' => ['hasAllowedMimeType', ['image/jpeg'], false],
+    'message' => '…',
+    'provider' => 'upload',
+]);
+```
+
+For images, `ImageValidationTrait::isValidImage()` (below) is a stricter check — it actually parses the image header — and should be preferred over `hasAllowedMimeType` when you only accept images.
+
 ## Available Image Validation Rules
 
 The `ImageValidationTrait` provides the following validation methods:


### PR DESCRIPTION
## Summary

Two doc gaps left over from the recent merged PRs (#22, #24):

### `docs/Documentation/Validation.md`

Previously only covered the `ImageValidationTrait` rules. The `UploadValidationTrait` helpers (`isUnderPhpSizeLimit`, `isCompletedUpload`, etc.) had been undocumented since forever, and the new `hasAllowedExtension` / `hasAllowedMimeType` rules added in #22 were never written up. This PR adds:

- A "File-error checks" table (the `UPLOAD_ERR_*` family).
- A "Size checks" table.
- An "Allow-list checks" subsection with a worked example for both helpers, calling out the server-side sniff (default) vs. client-header (`$sniff = false`) tradeoff so consumers don't accidentally trust user-supplied `Content-Type`.

### `README.md`

Added a short "Admin backend" section pointing at Installation.md and naming:
- the entry point `/admin/file-storage`,
- the fail-closed `FileStorage.adminAccess` posture,
- the `adminLayout` switch,
- the optional `dereuromark/cakephp-queue` soft-dep for variant regeneration.

No code changes.

## Verification

- `vendor/bin/phpunit` — 86 tests, 221 assertions, all green.
- `vendor/bin/phpstan analyze` — clean.
- `vendor/bin/phpcs` — clean.
