### PR TITLE
Admin: download action, variants preview, dashboard cards, filter bar

### DIFF
--- a/src/Controller/Admin/FileStorageController.php
+++ b/src/Controller/Admin/FileStorageController.php
@@ -2,8 +2,11 @@
 
 namespace FileStorage\Controller\Admin;
 
+use Cake\Core\Configure;
 use Cake\Core\Plugin;
 use Cake\Http\Exception\BadRequestException;
+use Cake\Http\Exception\InternalErrorException;
+use Cake\Http\Exception\NotFoundException;
 use FileStorage\Service\CleanupService;
 
 /**
@@ -17,14 +20,109 @@ class FileStorageController extends FileStorageAppController
      */
     public function index()
     {
+        $query = $this->FileStorage->find();
+        $filters = $this->buildIndexFilters();
+        if ($filters !== []) {
+            $query->where($filters);
+        }
+
         $this->paginate = [
             'order' => ['created' => 'DESC'],
         ];
+        $fileStorage = $this->paginate($query);
 
-        $fileStorage = $this->paginate($this->FileStorage);
+        // Distinct lookups for the filter dropdowns. Same pattern the cleanup
+        // action uses — values are admin-supplied and rare to change, so we
+        // accept the two extra COUNT-DISTINCT-shaped queries per page render.
+        $models = $this->FileStorage->find()
+            ->select(['model'])
+            ->where(['model IS NOT' => null])
+            ->groupBy(['model'])
+            ->orderByAsc('model')
+            ->all()
+            ->extract('model')
+            ->toArray();
 
-        $this->set(compact('fileStorage'));
+        $collections = $this->FileStorage->find()
+            ->select(['collection'])
+            ->where(['collection IS NOT' => null])
+            ->groupBy(['collection'])
+            ->orderByAsc('collection')
+            ->all()
+            ->extract('collection')
+            ->toArray();
+
+        $this->set(compact('fileStorage', 'models', 'collections'));
         $this->set('queueLoaded', Plugin::isLoaded('Queue'));
+        $this->set('filterValues', $this->indexFilterValues());
+    }
+
+    /**
+     * Pull filter values from the query string with empty-skip semantics.
+     *
+     * Returns the *raw user input* (strings) so the index template can
+     * re-populate the form. {@see self::buildIndexFilters()} consumes the
+     * same source to produce ORM-ready WHERE conditions.
+     *
+     * @return array{model: string, collection: string, mime: string, q: string, created_from: string, created_to: string, min_size: string, fk: string}
+     */
+    protected function indexFilterValues(): array
+    {
+        return [
+            'model' => trim((string)$this->request->getQuery('model', '')),
+            'collection' => trim((string)$this->request->getQuery('collection', '')),
+            'mime' => trim((string)$this->request->getQuery('mime', '')),
+            'q' => trim((string)$this->request->getQuery('q', '')),
+            'created_from' => trim((string)$this->request->getQuery('created_from', '')),
+            'created_to' => trim((string)$this->request->getQuery('created_to', '')),
+            'min_size' => trim((string)$this->request->getQuery('min_size', '')),
+            'fk' => trim((string)$this->request->getQuery('fk', '')),
+        ];
+    }
+
+    /**
+     * Translate the raw filter inputs into ORM WHERE conditions.
+     *
+     * Empty values are dropped — we never emit a `WHERE created >= ''` style
+     * query. Mime uses prefix-LIKE so `image/` matches all images while
+     * keeping the index usable; filename match is substring (`q` like a
+     * search box) and accepts the index hit since this list is admin-sized.
+     *
+     * @return array<string, mixed>
+     */
+    protected function buildIndexFilters(): array
+    {
+        $values = $this->indexFilterValues();
+        $conditions = [];
+
+        if ($values['model'] !== '') {
+            $conditions['model'] = $values['model'];
+        }
+        if ($values['collection'] !== '') {
+            $conditions['collection'] = $values['collection'];
+        }
+        if ($values['mime'] !== '') {
+            $conditions['mime_type LIKE'] = $values['mime'] . '%';
+        }
+        if ($values['q'] !== '') {
+            $conditions['filename LIKE'] = '%' . $values['q'] . '%';
+        }
+        if ($values['created_from'] !== '') {
+            $conditions['created >='] = $values['created_from'];
+        }
+        if ($values['created_to'] !== '') {
+            // Inclusive end-of-day so the date input matches user intent.
+            $conditions['created <='] = $values['created_to'] . ' 23:59:59';
+        }
+        if ($values['min_size'] !== '' && is_numeric($values['min_size'])) {
+            // UI emits MB as float; convert to bytes here.
+            $conditions['filesize >='] = (int)round((float)$values['min_size'] * 1024 * 1024);
+        }
+        if ($values['fk'] !== '' && ctype_digit($values['fk'])) {
+            $conditions['foreign_key'] = (int)$values['fk'];
+        }
+
+        return $conditions;
     }
 
     /**
@@ -231,5 +329,72 @@ class FileStorageController extends FileStorageAppController
         $this->Flash->success(__('Variant regeneration job has been queued for {0}.', h($entity->filename)));
 
         return $this->redirect($this->referer(['action' => 'index']));
+    }
+
+    /**
+     * Stream a stored file (or one of its variants) back to the admin caller.
+     *
+     * Adapter-agnostic: reads via the configured Flysystem adapter so it works
+     * for Local, S3, etc. Defaults to attachment disposition; pass `?inline=1`
+     * to render inline (used by the variants preview in `view`).
+     *
+     * Query params:
+     *   - `variant` Variant name (e.g. `thumb`). Empty/missing → main file.
+     *   - `inline` Truthy → `Content-Disposition: inline`. Otherwise `attachment`.
+     *
+     * @param string|null $id File Storage id.
+     *
+     * @throws \Cake\Http\Exception\NotFoundException When the row, path, or backing file is missing.
+     * @throws \Cake\Http\Exception\InternalErrorException When no adapter is configured.
+     *
+     * @return \Cake\Http\Response
+     */
+    public function download($id = null)
+    {
+        $entity = $this->FileStorage->get($id);
+        $variant = (string)$this->request->getQuery('variant', '');
+        $inline = (bool)$this->request->getQuery('inline');
+
+        if (!$entity->adapter) {
+            throw new NotFoundException(__d('file_storage', 'File is not stored on any adapter.'));
+        }
+
+        if ($variant !== '') {
+            $path = $entity->getVariantPath($variant);
+            $base = pathinfo((string)$entity->filename, PATHINFO_FILENAME);
+            $ext = $entity->extension !== null ? '.' . $entity->extension : '';
+            $downloadName = $base . '_' . $variant . $ext;
+        } else {
+            $path = $entity->path;
+            $downloadName = (string)$entity->filename;
+        }
+
+        if (!$path) {
+            throw new NotFoundException(__d('file_storage', 'No path stored for the requested file.'));
+        }
+
+        $fileStorage = Configure::read('FileStorage.behaviorConfig.fileStorage');
+        if ($fileStorage === null) {
+            throw new InternalErrorException(__d('file_storage', 'FileStorage adapter not configured.'));
+        }
+
+        $adapter = $fileStorage->getStorage((string)$entity->adapter);
+        if (!$adapter->fileExists($path)) {
+            throw new NotFoundException(__d('file_storage', 'Backing file is missing on the adapter.'));
+        }
+
+        $mime = (string)$entity->mime_type !== '' ? (string)$entity->mime_type : 'application/octet-stream';
+        $response = $this->response
+            ->withType($mime)
+            ->withStringBody($adapter->read($path));
+
+        if ($inline) {
+            return $response->withHeader(
+                'Content-Disposition',
+                'inline; filename="' . str_replace('"', '', $downloadName) . '"',
+            );
+        }
+
+        return $response->withDownload($downloadName);
     }
 }

--- a/src/Controller/Admin/FileStorageDashboardController.php
+++ b/src/Controller/Admin/FileStorageDashboardController.php
@@ -83,6 +83,29 @@ class FileStorageDashboardController extends FileStorageAppController
             ->all()
             ->toList();
 
+        // Top mime types — answers "are we storing too many of X?" at a glance.
+        $byMime = $this->FileStorage->find()
+            ->select([
+                'mime_type',
+                'count' => 'COUNT(*)',
+                'bytes' => 'SUM(filesize)',
+            ])
+            ->where(['mime_type IS NOT' => null])
+            ->groupBy(['mime_type'])
+            ->orderByDesc('bytes')
+            ->limit(10)
+            ->disableHydration()
+            ->all()
+            ->toList();
+
+        // Top size hogs — answers "where is the disk going?"
+        $largest = $this->FileStorage->find()
+            ->where(['filesize IS NOT' => null])
+            ->orderByDesc('filesize')
+            ->limit(10)
+            ->all()
+            ->toArray();
+
         $recent = $this->FileStorage->find()
             ->orderByDesc('created')
             ->limit(10)
@@ -96,6 +119,8 @@ class FileStorageDashboardController extends FileStorageAppController
             'byCollection',
             'byModel',
             'byAdapter',
+            'byMime',
+            'largest',
             'recent',
         ));
         $this->set('queueLoaded', Plugin::isLoaded('Queue'));

--- a/templates/Admin/FileStorage/index.php
+++ b/templates/Admin/FileStorage/index.php
@@ -2,6 +2,9 @@
 /**
  * @var \Cake\View\View $this
  * @var \Cake\Datasource\ResultSetInterface<\FileStorage\Model\Entity\FileStorage> $fileStorage
+ * @var array<int, string> $models
+ * @var array<int, string> $collections
+ * @var array{model: string, collection: string, mime: string, q: string, created_from: string, created_to: string, min_size: string, fk: string} $filterValues
  * @var bool $queueLoaded
  */
 
@@ -9,10 +12,97 @@ use Cake\Core\Plugin;
 
 $this->assign('title', __d('file_storage', 'Files'));
 $cspNonce = (string)$this->getRequest()->getAttribute('cspNonce', '');
+
+$activeFilters = array_filter($filterValues, static fn (string $v): bool => $v !== '');
 ?>
 <h1 class="h3 mb-3 d-flex justify-content-between align-items-center">
     <span><i class="fas fa-file me-2 text-primary"></i><?= __d('file_storage', 'Files') ?></span>
 </h1>
+
+<form method="get" class="card mb-3">
+    <div class="card-header py-2 d-flex justify-content-between align-items-center">
+        <span><i class="fas fa-filter me-2"></i><?= __d('file_storage', 'Filters') ?></span>
+        <?php if ($activeFilters): ?>
+            <span class="badge bg-primary"><?= count($activeFilters) ?> <?= __d('file_storage', 'active') ?></span>
+        <?php endif; ?>
+    </div>
+    <div class="card-body p-2">
+        <div class="row g-2">
+            <div class="col-md-3 col-lg-2">
+                <label class="form-label small mb-1"><?= __d('file_storage', 'Model') ?></label>
+                <select class="form-select form-select-sm" name="model">
+                    <option value=""><?= __d('file_storage', '— all —') ?></option>
+                    <?php foreach ($models as $modelOption): ?>
+                        <option value="<?= h($modelOption) ?>" <?= $filterValues['model'] === $modelOption ? 'selected' : '' ?>><?= h($modelOption) ?></option>
+                    <?php endforeach; ?>
+                </select>
+            </div>
+            <div class="col-md-3 col-lg-2">
+                <label class="form-label small mb-1"><?= __d('file_storage', 'Collection') ?></label>
+                <select class="form-select form-select-sm" name="collection">
+                    <option value=""><?= __d('file_storage', '— all —') ?></option>
+                    <?php foreach ($collections as $collectionOption): ?>
+                        <option value="<?= h($collectionOption) ?>" <?= $filterValues['collection'] === $collectionOption ? 'selected' : '' ?>><?= h($collectionOption) ?></option>
+                    <?php endforeach; ?>
+                </select>
+            </div>
+            <div class="col-md-3 col-lg-2">
+                <label class="form-label small mb-1"><?= __d('file_storage', 'Mime prefix') ?></label>
+                <input type="text" class="form-control form-control-sm" name="mime"
+                    value="<?= h($filterValues['mime']) ?>"
+                    list="fs-mime-suggestions"
+                    placeholder="image/">
+                <datalist id="fs-mime-suggestions">
+                    <option value="image/">
+                    <option value="application/pdf">
+                    <option value="video/">
+                    <option value="audio/">
+                    <option value="text/">
+                </datalist>
+            </div>
+            <div class="col-md-3 col-lg-3">
+                <label class="form-label small mb-1"><?= __d('file_storage', 'Filename contains') ?></label>
+                <input type="text" class="form-control form-control-sm" name="q"
+                    value="<?= h($filterValues['q']) ?>"
+                    placeholder="<?= h(__d('file_storage', 'substring match')) ?>">
+            </div>
+            <div class="col-md-3 col-lg-1">
+                <label class="form-label small mb-1"><?= __d('file_storage', 'FK') ?></label>
+                <input type="number" class="form-control form-control-sm" name="fk"
+                    value="<?= h($filterValues['fk']) ?>"
+                    min="0" step="1"
+                    placeholder="<?= h(__d('file_storage', 'id')) ?>">
+            </div>
+            <div class="col-md-3 col-lg-2">
+                <label class="form-label small mb-1"><?= __d('file_storage', 'Min size (MB)') ?></label>
+                <input type="number" class="form-control form-control-sm" name="min_size"
+                    value="<?= h($filterValues['min_size']) ?>"
+                    min="0" step="0.1"
+                    placeholder="0">
+            </div>
+            <div class="col-md-3 col-lg-2">
+                <label class="form-label small mb-1"><?= __d('file_storage', 'Created from') ?></label>
+                <input type="date" class="form-control form-control-sm" name="created_from"
+                    value="<?= h($filterValues['created_from']) ?>">
+            </div>
+            <div class="col-md-3 col-lg-2">
+                <label class="form-label small mb-1"><?= __d('file_storage', 'Created to') ?></label>
+                <input type="date" class="form-control form-control-sm" name="created_to"
+                    value="<?= h($filterValues['created_to']) ?>">
+            </div>
+            <div class="col-md-12 col-lg d-flex align-items-end gap-2">
+                <button type="submit" class="btn btn-sm btn-primary">
+                    <i class="fas fa-search me-1"></i><?= __d('file_storage', 'Filter') ?>
+                </button>
+                <?php if ($activeFilters): ?>
+                    <a href="<?= $this->Url->build(['action' => 'index']) ?>" class="btn btn-sm btn-outline-secondary">
+                        <i class="fas fa-times me-1"></i><?= __d('file_storage', 'Reset') ?>
+                    </a>
+                <?php endif; ?>
+            </div>
+        </div>
+    </div>
+</form>
 
 <?= $this->Form->create(null, [
     'url' => ['action' => 'deleteBulk'],
@@ -67,6 +157,9 @@ $cspNonce = (string)$this->getRequest()->getAttribute('cspNonce', '');
                     <td class="text-end">
                         <a class="btn btn-sm btn-outline-secondary" href="<?= $this->Url->build(['action' => 'view', $entry->id]) ?>" title="<?= h(__d('file_storage', 'View')) ?>">
                             <i class="fas fa-eye"></i>
+                        </a>
+                        <a class="btn btn-sm btn-outline-secondary" href="<?= $this->Url->build(['action' => 'download', $entry->id]) ?>" title="<?= h(__d('file_storage', 'Download')) ?>">
+                            <i class="fas fa-download"></i>
                         </a>
                         <a class="btn btn-sm btn-outline-secondary" href="<?= $this->Url->build(['action' => 'edit', $entry->id]) ?>" title="<?= h(__d('file_storage', 'Edit')) ?>">
                             <i class="fas fa-pen"></i>

--- a/templates/Admin/FileStorage/view.php
+++ b/templates/Admin/FileStorage/view.php
@@ -1,95 +1,277 @@
 <?php
 /**
- * @var \App\View\AppView $this
+ * @var \Cake\View\View $this
  * @var \FileStorage\Model\Entity\FileStorage $fileStorage
+ * @var bool $queueLoaded
  */
 
 use Brick\VarExporter\VarExporter;
+use Cake\Core\Configure;
 
-$cspNonce = (string)$this->getRequest()->getAttribute('cspNonce', '');
+$this->assign('title', $fileStorage->filename ?? __d('file_storage', 'File'));
+
+$humanBytes = function (int|float|null $bytes): string {
+    if ($bytes === null) {
+        return '—';
+    }
+    $units = ['B', 'KB', 'MB', 'GB', 'TB'];
+    $i = 0;
+    $bytes = (float)$bytes;
+    while ($bytes >= 1024 && $i < count($units) - 1) {
+        $bytes /= 1024;
+        $i++;
+    }
+
+    return number_format($bytes, $i === 0 ? 0 : 2) . ' ' . $units[$i];
+};
+
+// Resolve the configured Flysystem adapter once so the variants table can show
+// existence + on-disk size without doing N queries from inside the template.
+$fileStorageService = Configure::read('FileStorage.behaviorConfig.fileStorage');
+$adapter = null;
+if ($fileStorageService !== null && $fileStorage->adapter !== null) {
+    try {
+        $adapter = $fileStorageService->getStorage((string)$fileStorage->adapter);
+    } catch (\Throwable $e) {
+        $adapter = null;
+    }
+}
+
+$probe = function (?string $path) use ($adapter): array {
+    if ($adapter === null || $path === null || $path === '') {
+        return ['exists' => false, 'size' => null];
+    }
+    try {
+        if (!$adapter->fileExists($path)) {
+            return ['exists' => false, 'size' => null];
+        }
+        $size = $adapter->fileSize($path)->fileSize();
+    } catch (\Throwable $e) {
+        return ['exists' => false, 'size' => null];
+    }
+
+    return ['exists' => true, 'size' => $size];
+};
+
+$isImage = $fileStorage->mime_type !== null && str_starts_with((string)$fileStorage->mime_type, 'image/');
+$mainProbe = $probe($fileStorage->path);
+
+$variants = (array)$fileStorage->variants;
 ?>
-<div class="row">
-    <aside class="column actions large-3 medium-4 col-sm-4 col-xs-12">
-        <ul class="side-nav nav nav-pills flex-column">
-            <li class="nav-item heading"><?= __('Actions') ?></li>
-            <li class="nav-item"><?= $this->Html->link(__('Edit {0}', __('File Storage')), ['action' => 'edit', $fileStorage->id], ['class' => 'side-nav-item']) ?></li>
-            <li class="nav-item"><?= $this->Form->postButton(__('Delete {0}', __('File Storage')), ['action' => 'delete', $fileStorage->id], [
-                'class' => 'side-nav-item btn btn-link text-start w-100',
+<h1 class="h3 mb-4 d-flex justify-content-between align-items-start gap-3">
+    <span>
+        <i class="fas fa-file me-2 text-primary"></i><?= h($fileStorage->filename) ?>
+    </span>
+    <span class="d-flex gap-2 flex-wrap">
+        <a class="btn btn-sm btn-outline-secondary" href="<?= $this->Url->build(['action' => 'index']) ?>">
+            <i class="fas fa-arrow-left me-1"></i><?= __d('file_storage', 'Back to list') ?>
+        </a>
+        <a class="btn btn-sm btn-primary" href="<?= $this->Url->build(['action' => 'download', $fileStorage->id]) ?>">
+            <i class="fas fa-download me-1"></i><?= __d('file_storage', 'Download') ?>
+        </a>
+        <a class="btn btn-sm btn-outline-primary" href="<?= $this->Url->build(['action' => 'edit', $fileStorage->id]) ?>">
+            <i class="fas fa-pen me-1"></i><?= __d('file_storage', 'Edit') ?>
+        </a>
+        <?php if ($queueLoaded): ?>
+            <?= $this->Form->postButton(
+                '<i class="fas fa-sync me-1"></i>' . __d('file_storage', 'Regenerate variants'),
+                ['action' => 'regenerateVariants', $fileStorage->id],
+                [
+                    'class' => 'btn btn-sm btn-outline-info',
+                    'escapeTitle' => false,
+                    'form' => [
+                        'class' => 'd-inline',
+                        'data-confirm-message' => __d('file_storage', 'Queue a variant regeneration job for {0}?', $fileStorage->filename),
+                    ],
+                ],
+            ) ?>
+        <?php endif; ?>
+        <?= $this->Form->postButton(
+            '<i class="fas fa-trash me-1"></i>' . __d('file_storage', 'Delete'),
+            ['action' => 'delete', $fileStorage->id],
+            [
+                'class' => 'btn btn-sm btn-outline-danger',
+                'escapeTitle' => false,
                 'form' => [
                     'class' => 'd-inline',
-                    'data-confirm-message' => __('Are you sure you want to delete # {0}?', $fileStorage->id),
+                    'data-confirm-message' => __d('file_storage', 'Delete {0}? This cannot be undone.', $fileStorage->filename),
                 ],
-            ]) ?></li>
-            <li class="nav-item"><?= $this->Html->link(__('List {0}', __('File Storage')), ['action' => 'index'], ['class' => 'side-nav-item']) ?></li>
-        </ul>
-    </aside>
-    <div class="column-responsive column-80 content large-9 medium-8 col-sm-8 col-xs-12">
-        <div class="fileStorage view content">
-            <h2><?= h($fileStorage->filename) ?></h2>
+            ],
+        ) ?>
+    </span>
+</h1>
 
-            <table class="table table-striped">
-                <tr>
-                    <th><?= __('Model') ?></th>
-                    <td><?= h($fileStorage->model) ?> : <?= $this->Number->format($fileStorage->foreign_key) ?></td>
-                </tr>
-                <tr>
-                    <th><?= __('Collection') ?></th>
-                    <td><?= h($fileStorage->collection) ?></td>
-                </tr>
-                <tr>
-                    <th><?= __('Filename') ?></th>
-                    <td><?= h($fileStorage->filename) ?></td>
-                </tr>
-                <tr>
-                    <th><?= __('Mime Type') ?></th>
-                    <td><?= h($fileStorage->mime_type) ?></td>
-                </tr>
-                <tr>
-                    <th><?= __('Extension') ?></th>
-                    <td><?= h($fileStorage->extension) ?></td>
-                </tr>
-                <tr>
-                    <th><?= __('Path') ?></th>
-                    <td><?= h($fileStorage->path) ?></td>
-                </tr>
-                <tr>
-                    <th><?= __('Adapter') ?></th>
-                    <td><?= h($fileStorage->adapter) ?></td>
-                </tr>
-                <tr>
-                    <th><?= __('Variants') ?></th>
-                    <td><pre><?= VarExporter::export(h($fileStorage->variants), VarExporter::TRAILING_COMMA_IN_ARRAY); ?></pre></td>
-                </tr>
-                <tr>
-                    <th><?= __('Metadata') ?></th>
-                    <td><pre><?= VarExporter::export(h($fileStorage->metadata), VarExporter::TRAILING_COMMA_IN_ARRAY); ?></pre></td>
-                </tr>
-                <tr>
-                    <th><?= __('User') ?></th>
-                    <td><?= h($fileStorage->user_id) ?></td>
-                </tr>
-                <tr>
-                    <th><?= __('Filesize') ?></th>
-                    <td><?= $this->Number->format($fileStorage->filesize) ?></td>
-                </tr>
-                <tr>
-                    <th><?= __('Created') ?></th>
-                    <td><?= $this->Time->nice($fileStorage->created) ?></td>
-                </tr>
-                <tr>
-                    <th><?= __('Modified') ?></th>
-                    <td><?= $this->Time->nice($fileStorage->modified) ?></td>
-                </tr>
-            </table>
+<div class="row g-3">
+    <div class="col-lg-8">
+        <div class="card mb-3">
+            <div class="card-header"><i class="fas fa-info-circle me-2"></i><?= __d('file_storage', 'Details') ?></div>
+            <div class="card-body p-0">
+                <table class="table table-sm mb-0">
+                    <tbody>
+                        <tr>
+                            <th class="w-25"><?= __d('file_storage', 'Model') ?></th>
+                            <td><code><?= h($fileStorage->model) ?></code> : <?= h((string)$fileStorage->foreign_key) ?></td>
+                        </tr>
+                        <tr>
+                            <th><?= __d('file_storage', 'Collection') ?></th>
+                            <td><?= h($fileStorage->collection) ?></td>
+                        </tr>
+                        <tr>
+                            <th><?= __d('file_storage', 'Mime / Extension') ?></th>
+                            <td><code><?= h($fileStorage->mime_type) ?></code> &middot; <?= h($fileStorage->extension) ?></td>
+                        </tr>
+                        <tr>
+                            <th><?= __d('file_storage', 'Adapter') ?></th>
+                            <td><?= h($fileStorage->adapter) ?></td>
+                        </tr>
+                        <tr>
+                            <th><?= __d('file_storage', 'Path') ?></th>
+                            <td><code class="small"><?= h($fileStorage->path) ?></code></td>
+                        </tr>
+                        <tr>
+                            <th><?= __d('file_storage', 'DB filesize') ?></th>
+                            <td><?= h($humanBytes($fileStorage->filesize)) ?> <span class="text-muted small">(<?= number_format((int)$fileStorage->filesize) ?> <?= __d('file_storage', 'bytes') ?>)</span></td>
+                        </tr>
+                        <tr>
+                            <th><?= __d('file_storage', 'Hash') ?></th>
+                            <td><code class="small"><?= h($fileStorage->hash) ?></code></td>
+                        </tr>
+                        <tr>
+                            <th><?= __d('file_storage', 'Created') ?></th>
+                            <td><?= h($fileStorage->created?->format('Y-m-d H:i:s') ?? '') ?></td>
+                        </tr>
+                        <tr>
+                            <th><?= __d('file_storage', 'Modified') ?></th>
+                            <td><?= h($fileStorage->modified?->format('Y-m-d H:i:s') ?? '') ?></td>
+                        </tr>
+                        <tr>
+                            <th><?= __d('file_storage', 'User') ?></th>
+                            <td><?= h((string)$fileStorage->user_id) ?></td>
+                        </tr>
+                    </tbody>
+                </table>
+            </div>
+        </div>
+
+        <div class="card mb-3">
+            <div class="card-header d-flex justify-content-between align-items-center">
+                <span><i class="fas fa-images me-2"></i><?= __d('file_storage', 'Variants') ?></span>
+                <span class="badge bg-secondary"><?= count($variants) ?></span>
+            </div>
+            <div class="card-body p-0">
+                <table class="table table-sm mb-0 align-middle">
+                    <thead>
+                        <tr>
+                            <th><?= __d('file_storage', 'Preview') ?></th>
+                            <th><?= __d('file_storage', 'Variant') ?></th>
+                            <th><?= __d('file_storage', 'Path') ?></th>
+                            <th class="text-end"><?= __d('file_storage', 'Size on disk') ?></th>
+                            <th class="text-center"><?= __d('file_storage', 'State') ?></th>
+                            <th class="text-end"><?= __d('file_storage', 'Actions') ?></th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <td style="width:80px;">
+                                <?php if ($isImage && $mainProbe['exists']): ?>
+                                    <img src="<?= $this->Url->build(['action' => 'download', $fileStorage->id, '?' => ['inline' => 1]]) ?>"
+                                        alt="<?= h($fileStorage->filename) ?>"
+                                        style="max-width:64px;max-height:64px;object-fit:contain;border-radius:4px;">
+                                <?php else: ?>
+                                    <i class="fas fa-file fa-2x text-muted"></i>
+                                <?php endif; ?>
+                            </td>
+                            <td><strong><?= __d('file_storage', 'main') ?></strong></td>
+                            <td><code class="small"><?= h($fileStorage->path) ?></code></td>
+                            <td class="text-end"><?= h($humanBytes($mainProbe['size'])) ?></td>
+                            <td class="text-center">
+                                <?php if ($mainProbe['exists']): ?>
+                                    <span class="badge bg-success"><i class="fas fa-check"></i> <?= __d('file_storage', 'present') ?></span>
+                                <?php else: ?>
+                                    <span class="badge bg-danger"><i class="fas fa-times"></i> <?= __d('file_storage', 'missing') ?></span>
+                                <?php endif; ?>
+                            </td>
+                            <td class="text-end">
+                                <a class="btn btn-sm btn-outline-secondary" href="<?= $this->Url->build(['action' => 'download', $fileStorage->id]) ?>"
+                                    title="<?= h(__d('file_storage', 'Download')) ?>">
+                                    <i class="fas fa-download"></i>
+                                </a>
+                                <a class="btn btn-sm btn-outline-secondary" target="_blank" rel="noopener"
+                                    href="<?= $this->Url->build(['action' => 'download', $fileStorage->id, '?' => ['inline' => 1]]) ?>"
+                                    title="<?= h(__d('file_storage', 'Open inline')) ?>">
+                                    <i class="fas fa-external-link-alt"></i>
+                                </a>
+                            </td>
+                        </tr>
+                        <?php foreach ($variants as $name => $details): ?>
+                            <?php
+                            $variantPath = is_array($details) ? ($details['path'] ?? null) : null;
+                            $vProbe = $probe(is_string($variantPath) ? $variantPath : null);
+                            $variantIsImage = $isImage; // assume same family as main
+                            ?>
+                            <tr>
+                                <td>
+                                    <?php if ($variantIsImage && $vProbe['exists']): ?>
+                                        <img src="<?= $this->Url->build(['action' => 'download', $fileStorage->id, '?' => ['inline' => 1, 'variant' => $name]]) ?>"
+                                            alt="<?= h((string)$name) ?>"
+                                            style="max-width:64px;max-height:64px;object-fit:contain;border-radius:4px;">
+                                    <?php else: ?>
+                                        <i class="fas fa-image fa-2x text-muted"></i>
+                                    <?php endif; ?>
+                                </td>
+                                <td><?= h((string)$name) ?></td>
+                                <td><code class="small"><?= h((string)$variantPath) ?></code></td>
+                                <td class="text-end"><?= h($humanBytes($vProbe['size'])) ?></td>
+                                <td class="text-center">
+                                    <?php if ($vProbe['exists']): ?>
+                                        <span class="badge bg-success"><i class="fas fa-check"></i> <?= __d('file_storage', 'present') ?></span>
+                                    <?php elseif ($variantPath): ?>
+                                        <span class="badge bg-danger"><i class="fas fa-times"></i> <?= __d('file_storage', 'missing') ?></span>
+                                    <?php else: ?>
+                                        <span class="badge bg-secondary"><?= __d('file_storage', 'no path') ?></span>
+                                    <?php endif; ?>
+                                </td>
+                                <td class="text-end">
+                                    <?php if ($variantPath): ?>
+                                        <a class="btn btn-sm btn-outline-secondary" href="<?= $this->Url->build(['action' => 'download', $fileStorage->id, '?' => ['variant' => $name]]) ?>"
+                                            title="<?= h(__d('file_storage', 'Download')) ?>">
+                                            <i class="fas fa-download"></i>
+                                        </a>
+                                        <a class="btn btn-sm btn-outline-secondary" target="_blank" rel="noopener"
+                                            href="<?= $this->Url->build(['action' => 'download', $fileStorage->id, '?' => ['inline' => 1, 'variant' => $name]]) ?>"
+                                            title="<?= h(__d('file_storage', 'Open inline')) ?>">
+                                            <i class="fas fa-external-link-alt"></i>
+                                        </a>
+                                    <?php endif; ?>
+                                </td>
+                            </tr>
+                        <?php endforeach; ?>
+                        <?php if (!$variants): ?>
+                            <tr>
+                                <td colspan="6" class="text-center text-muted py-3">
+                                    <?= __d('file_storage', 'No variants generated.') ?>
+                                </td>
+                            </tr>
+                        <?php endif; ?>
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    </div>
+
+    <div class="col-lg-4">
+        <div class="card mb-3">
+            <div class="card-header"><i class="fas fa-code me-2"></i><?= __d('file_storage', 'Variants (raw)') ?></div>
+            <div class="card-body p-2">
+                <pre class="small mb-0"><?= h(VarExporter::export($fileStorage->variants ?: [], VarExporter::TRAILING_COMMA_IN_ARRAY)) ?></pre>
+            </div>
+        </div>
+
+        <div class="card">
+            <div class="card-header"><i class="fas fa-tags me-2"></i><?= __d('file_storage', 'Metadata') ?></div>
+            <div class="card-body p-2">
+                <pre class="small mb-0"><?= h(VarExporter::export($fileStorage->metadata ?: [], VarExporter::TRAILING_COMMA_IN_ARRAY)) ?></pre>
+            </div>
         </div>
     </div>
 </div>
-<script<?= $cspNonce !== '' ? ' nonce="' . h($cspNonce) . '"' : '' ?>>
-document.querySelectorAll('form[data-confirm-message]').forEach(function(form) {
-    form.addEventListener('submit', function(e) {
-        if (!confirm(this.dataset.confirmMessage)) {
-            e.preventDefault();
-        }
-    });
-});
-</script>

--- a/templates/Admin/FileStorageDashboard/index.php
+++ b/templates/Admin/FileStorageDashboard/index.php
@@ -7,6 +7,8 @@
  * @var array<int, array{collection: string, count: int, bytes: int|float}> $byCollection
  * @var array<int, array{model: string, count: int, bytes: int|float}> $byModel
  * @var array<int, array{adapter: string, count: int}> $byAdapter
+ * @var array<int, array{mime_type: string, count: int, bytes: int|float}> $byMime
+ * @var array<int, \FileStorage\Model\Entity\FileStorage> $largest
  * @var array<int, \FileStorage\Model\Entity\FileStorage> $recent
  * @var bool $queueLoaded
  */
@@ -143,6 +145,70 @@ $humanBytes = function (int|float $bytes): string {
                         <?php endforeach; ?>
                         <?php if (!$byAdapter): ?>
                             <tr><td colspan="2" class="text-center text-muted py-3"><?= __d('file_storage', 'No data.') ?></td></tr>
+                        <?php endif; ?>
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    </div>
+
+    <div class="col-lg-6">
+        <div class="card">
+            <div class="card-header"><i class="fas fa-file-code me-2"></i><?= __d('file_storage', 'Top Mime Types') ?></div>
+            <div class="card-body p-0">
+                <table class="table table-sm mb-0">
+                    <thead>
+                        <tr>
+                            <th><?= __d('file_storage', 'Mime') ?></th>
+                            <th class="text-end"><?= __d('file_storage', 'Files') ?></th>
+                            <th class="text-end"><?= __d('file_storage', 'Size') ?></th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <?php foreach ($byMime as $row): ?>
+                            <tr>
+                                <td><code><?= h($row['mime_type']) ?></code></td>
+                                <td class="text-end"><?= number_format((int)$row['count']) ?></td>
+                                <td class="text-end"><?= h($humanBytes((int)$row['bytes'])) ?></td>
+                            </tr>
+                        <?php endforeach; ?>
+                        <?php if (!$byMime): ?>
+                            <tr><td colspan="3" class="text-center text-muted py-3"><?= __d('file_storage', 'No data.') ?></td></tr>
+                        <?php endif; ?>
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    </div>
+
+    <div class="col-lg-6">
+        <div class="card">
+            <div class="card-header"><i class="fas fa-weight-hanging me-2"></i><?= __d('file_storage', 'Largest Files') ?></div>
+            <div class="card-body p-0">
+                <table class="table table-sm mb-0">
+                    <thead>
+                        <tr>
+                            <th><?= __d('file_storage', 'Filename') ?></th>
+                            <th><?= __d('file_storage', 'Collection') ?></th>
+                            <th class="text-end"><?= __d('file_storage', 'Size') ?></th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <?php foreach ($largest as $entry): ?>
+                            <tr>
+                                <td>
+                                    <?= $this->Html->link(
+                                        h($entry->filename),
+                                        ['plugin' => 'FileStorage', 'prefix' => 'Admin', 'controller' => 'FileStorage', 'action' => 'view', $entry->id],
+                                        ['escapeTitle' => false],
+                                    ) ?>
+                                </td>
+                                <td><?= h($entry->collection) ?></td>
+                                <td class="text-end"><?= h($humanBytes((int)$entry->filesize)) ?></td>
+                            </tr>
+                        <?php endforeach; ?>
+                        <?php if (!$largest): ?>
+                            <tr><td colspan="3" class="text-center text-muted py-3"><?= __d('file_storage', 'No data.') ?></td></tr>
                         <?php endif; ?>
                     </tbody>
                 </table>

--- a/tests/TestCase/Controller/Admin/FileStorageControllerTest.php
+++ b/tests/TestCase/Controller/Admin/FileStorageControllerTest.php
@@ -5,6 +5,7 @@ namespace FileStorage\Test\TestCase\Controller\Admin;
 use Cake\Core\Configure;
 use Cake\Http\Exception\BadRequestException;
 use Cake\Http\Exception\ForbiddenException;
+use Cake\Http\Exception\NotFoundException;
 use Cake\Http\ServerRequest;
 use Cake\TestSuite\IntegrationTestTrait;
 use Cake\TestSuite\TestCase;
@@ -255,5 +256,130 @@ class FileStorageControllerTest extends TestCase
         $this->expectException(BadRequestException::class);
 
         $this->post(['controller' => 'FileStorage', 'action' => 'regenerateVariants', 1, 'prefix' => 'Admin', 'plugin' => 'FileStorage']);
+    }
+
+    /**
+     * @return void
+     */
+    public function testIndexExposesFilterMetadata(): void
+    {
+        $this->get(['controller' => 'FileStorage', 'action' => 'index', 'prefix' => 'Admin', 'plugin' => 'FileStorage']);
+
+        $this->assertResponseOk();
+        $this->assertSame(['Item'], $this->viewVariable('models'));
+        $this->assertNotNull($this->viewVariable('collections'));
+
+        $values = $this->viewVariable('filterValues');
+        $this->assertIsArray($values);
+        $this->assertSame('', $values['model']);
+        $this->assertSame('', $values['mime']);
+    }
+
+    /**
+     * @return void
+     */
+    public function testIndexFilterByMimePrefix(): void
+    {
+        // Fixture has 1 png + 3 jpg rows; `image/p` should narrow to the png only.
+        $this->get([
+            'controller' => 'FileStorage',
+            'action' => 'index',
+            'prefix' => 'Admin',
+            'plugin' => 'FileStorage',
+            '?' => ['mime' => 'image/p'],
+        ]);
+
+        $this->assertResponseOk();
+        $fileStorage = $this->viewVariable('fileStorage');
+        $this->assertCount(1, $fileStorage);
+        $values = $this->viewVariable('filterValues');
+        $this->assertSame('image/p', $values['mime']);
+    }
+
+    /**
+     * @return void
+     */
+    public function testIndexFilterByFilenameSubstring(): void
+    {
+        // Three fixture rows have `titus` in the filename, one does not.
+        $this->get([
+            'controller' => 'FileStorage',
+            'action' => 'index',
+            'prefix' => 'Admin',
+            'plugin' => 'FileStorage',
+            '?' => ['q' => 'titus'],
+        ]);
+
+        $this->assertResponseOk();
+        $this->assertCount(3, $this->viewVariable('fileStorage'));
+    }
+
+    /**
+     * @return void
+     */
+    public function testIndexFilterByMinSize(): void
+    {
+        // 0.1 MB ≈ 104857 bytes → drops the two small fixture rows
+        // (12345 + 54321) and keeps the two 335872-byte ones.
+        $this->get([
+            'controller' => 'FileStorage',
+            'action' => 'index',
+            'prefix' => 'Admin',
+            'plugin' => 'FileStorage',
+            '?' => ['min_size' => '0.1'],
+        ]);
+
+        $this->assertResponseOk();
+        $this->assertCount(2, $this->viewVariable('fileStorage'));
+    }
+
+    /**
+     * @return void
+     */
+    public function testIndexFilterByForeignKey(): void
+    {
+        $this->get([
+            'controller' => 'FileStorage',
+            'action' => 'index',
+            'prefix' => 'Admin',
+            'plugin' => 'FileStorage',
+            '?' => ['fk' => '4'],
+        ]);
+
+        $this->assertResponseOk();
+        $rows = $this->viewVariable('fileStorage');
+        $this->assertCount(1, $rows);
+        $this->assertSame(4, $rows->items()->first()->foreign_key);
+    }
+
+    /**
+     * @return void
+     */
+    public function testIndexFilterIgnoresEmptyValues(): void
+    {
+        $this->get([
+            'controller' => 'FileStorage',
+            'action' => 'index',
+            'prefix' => 'Admin',
+            'plugin' => 'FileStorage',
+            '?' => ['model' => '', 'mime' => '', 'min_size' => ''],
+        ]);
+
+        $this->assertResponseOk();
+        $this->assertCount(4, $this->viewVariable('fileStorage'));
+    }
+
+    /**
+     * The fixture row points at `Item/cake.icon.png` on the test Local
+     * adapter, but no actual file exists there — the action must 404
+     * instead of returning a corrupted/empty body.
+     *
+     * @return void
+     */
+    public function testDownloadFailsWhenBackingFileMissing(): void
+    {
+        $this->expectException(NotFoundException::class);
+
+        $this->get(['controller' => 'FileStorage', 'action' => 'download', 1, 'prefix' => 'Admin', 'plugin' => 'FileStorage']);
     }
 }

--- a/tests/TestCase/Controller/Admin/FileStorageDashboardControllerTest.php
+++ b/tests/TestCase/Controller/Admin/FileStorageDashboardControllerTest.php
@@ -52,7 +52,15 @@ class FileStorageDashboardControllerTest extends TestCase
         $this->assertNotNull($this->viewVariable('byCollection'));
         $this->assertNotNull($this->viewVariable('byModel'));
         $this->assertNotNull($this->viewVariable('byAdapter'));
+        $this->assertNotNull($this->viewVariable('byMime'));
+        $this->assertNotNull($this->viewVariable('largest'));
         $this->assertNotNull($this->viewVariable('recent'));
+
+        // Largest is sorted by filesize DESC — first entry should be the
+        // largest fixture row (titus.jpg at 335872 bytes).
+        $largest = $this->viewVariable('largest');
+        $this->assertNotEmpty($largest);
+        $this->assertSame(335872, $largest[0]->filesize);
     }
 
     /**


### PR DESCRIPTION
## Summary

Builds on the standalone admin backend from #24 with the next round of day-to-day admin features. All four are cleanly separable but ship together because they exercise the same controller surface.

### Download action

`Admin/FileStorageController::download(\$id)` streams a stored file (or one of its variants) back to the admin caller via the configured Flysystem adapter — works for Local, S3, anything.

- `?variant=name` selects a generated variant (otherwise the main file)
- `?inline=1` switches to `Content-Disposition: inline` (used by the variants preview to render image thumbs in-page)
- Default disposition is `attachment` with the original filename
- Fails closed: 404 when the row, path, or backing file is missing; 500 when no adapter is configured

A download icon-button is added to each row in the file listing.

### Variants preview in `view`

The `view` action template was previously the auto-baked layout from pre-#24 — host-app sidebar classes, no Bootstrap-5, no awareness of the new admin shell. It is rewritten to match the rest of the standalone backend and gains a Variants table:

- One row per variant (plus a header row for the main file)
- Image thumbnails inline (rendered through the new `download` action with `?inline=1`), or a generic file icon for non-images
- Per-variant path, on-disk size (probed via the Flysystem adapter using `fileExists` + `fileSize`), and a present/missing/no-path state badge
- Per-variant download + open-inline buttons

The raw `variants` and `metadata` columns are still rendered as `VarExporter` blocks in a side card for power users.

### Dashboard: Top Mime Types and Largest Files

Two new cards on the dashboard answering questions the existing collection / model / adapter cards do not:

- **Top Mime Types** — top 10 by total bytes, with file count and aggregate size. Useful for spotting "we are storing a lot of PDFs/videos".
- **Largest Files** — top 10 rows by `filesize`, each linking to the row's `view` page. Direct answer to "where is the disk going?".

Both queries are bounded (`LIMIT 10`) and do not require a disk walk.

### Filter bar in the file listing

`index` gains a filter bar above the bulk-delete toolbar. Native CakePHP only — no `friendsofcake/search` dependency. URL params drive the form; shareable links work and the form re-populates from the URL.

Filter dimensions:

- `model` — exact match, dropdown populated from a distinct query
- `collection` — exact match, dropdown populated from a distinct query
- `mime` — prefix `LIKE 'X%'` so `image/` matches all images while keeping the index usable. Free-text input with a small datalist of common prefixes
- `q` — substring match against `filename` (admin-sized list, trading index hit for ergonomics)
- `created_from` / `created_to` — `>=` / `<=` with `23:59:59` appended to the upper bound for an inclusive date input
- `min_size` — UI accepts MB (float), converts to bytes for the query; rejects non-numeric input rather than silently producing a `>= 0`
- `fk` — exact match on `foreign_key`, gated by `ctype_digit` so the URL cannot smuggle non-numeric values into the int comparison

All filters AND together. Empty values are dropped before the query is built, so we never emit `WHERE created >= ''`. An "active filters" badge in the card header counts how many fields are currently narrowing the list, and a Reset link drops all params.

## Tests

\`tests/TestCase/Controller/Admin/FileStorageControllerTest\`:

- \`testIndexExposesFilterMetadata\` — verifies the new \`models\`, \`collections\`, \`filterValues\` view variables
- \`testIndexFilterByMimePrefix\`, \`testIndexFilterByFilenameSubstring\`, \`testIndexFilterByMinSize\`, \`testIndexFilterByForeignKey\`, \`testIndexFilterIgnoresEmptyValues\` — exercise each filter dimension
- \`testDownloadFailsWhenBackingFileMissing\` — fail-closed on the path the action takes when an adapter is configured but the file is not on disk (the most common production failure mode)

\`tests/TestCase/Controller/Admin/FileStorageDashboardControllerTest\`:

- Asserts the new \`byMime\` and \`largest\` view variables are populated and that \`largest\` is sorted descending (largest fixture row first)

## Verification

- \`composer test\` — 93 tests, 244 assertions, all green
- \`composer stan\` — clean
- \`composer cs-check\` — clean