### PR TITLE
Polish batch 2: type tightening, recursion-guard try/finally, doc note

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,13 @@ For background image-variant regeneration from the admin UI, install
 [`dereuromark/cakephp-queue`](https://github.com/dereuromark/cakephp-queue);
 without it the regenerate buttons render disabled.
 
+> [!NOTE]
+> Do not pre-fill the primary key on a FileStorage entity before saving.
+> Path generation runs through the `php-collective/file-storage` UUID
+> strategy; if a caller hands it a pre-set id, two concurrent saves with
+> the same id would race on `fileStorage->store()`. Let the table assign
+> the id.
+
 ## Documentation
 
 For documentation, as well as tutorials, see the [docs](docs/) directory of this repository.

--- a/src/Command/ImageVariantGenerateCommand.php
+++ b/src/Command/ImageVariantGenerateCommand.php
@@ -254,7 +254,7 @@ class ImageVariantGenerateCommand extends Command
      *
      * @return \Cake\Datasource\EntityInterface
      */
-    public function fileObjectToEntity(FileInterface $file, ?EntityInterface $entity)
+    public function fileObjectToEntity(FileInterface $file, ?EntityInterface $entity): EntityInterface
     {
         return $this->getTransformer()->fileObjectToEntity($file, $entity);
     }

--- a/src/Controller/Admin/FileStorageController.php
+++ b/src/Controller/Admin/FileStorageController.php
@@ -7,6 +7,7 @@ use Cake\Core\Plugin;
 use Cake\Http\Exception\BadRequestException;
 use Cake\Http\Exception\InternalErrorException;
 use Cake\Http\Exception\NotFoundException;
+use Cake\Http\Response;
 use FileStorage\Service\CleanupService;
 
 /**
@@ -16,9 +17,9 @@ use FileStorage\Service\CleanupService;
 class FileStorageController extends FileStorageAppController
 {
     /**
-     * @return \Cake\Http\Response|null|void Renders view
+     * @return \Cake\Http\Response|null Renders view
      */
-    public function index()
+    public function index(): ?Response
     {
         $query = $this->FileStorage->find();
         $filters = $this->buildIndexFilters();
@@ -55,6 +56,8 @@ class FileStorageController extends FileStorageAppController
         $this->set(compact('fileStorage', 'models', 'collections'));
         $this->set('queueLoaded', Plugin::isLoaded('Queue'));
         $this->set('filterValues', $this->indexFilterValues());
+
+        return null;
     }
 
     /**
@@ -130,22 +133,24 @@ class FileStorageController extends FileStorageAppController
      *
      * @param string|null $id File Storage id.
      *
-     * @return \Cake\Http\Response|null|void Renders view
+     * @return \Cake\Http\Response|null Renders view
      */
-    public function view($id = null)
+    public function view(?string $id = null): ?Response
     {
         $fileStorage = $this->FileStorage->get($id);
 
         $this->set(compact('fileStorage'));
         $this->set('queueLoaded', Plugin::isLoaded('Queue'));
+
+        return null;
     }
 
     /**
      * @param string|null $id File Storage id.
      *
-     * @return \Cake\Http\Response|null|void Redirects on successful edit, renders view otherwise.
+     * @return \Cake\Http\Response|null Redirects on successful edit, renders view otherwise.
      */
-    public function edit($id = null)
+    public function edit(?string $id = null): ?Response
     {
         $fileStorage = $this->FileStorage->get($id);
         if ($this->request->is(['patch', 'post', 'put'])) {
@@ -158,14 +163,16 @@ class FileStorageController extends FileStorageAppController
             $this->Flash->error(__('The file storage could not be saved. Please, try again.'));
         }
         $this->set(compact('fileStorage'));
+
+        return null;
     }
 
     /**
      * @param string|null $id File Storage id.
      *
-     * @return \Cake\Http\Response|null|void Redirects to index.
+     * @return \Cake\Http\Response|null Redirects to index.
      */
-    public function delete($id = null)
+    public function delete(?string $id = null): ?Response
     {
         $this->request->allowMethod(['post', 'delete']);
         $fileStorage = $this->FileStorage->get($id);
@@ -192,7 +199,7 @@ class FileStorageController extends FileStorageAppController
      *
      * @return \Cake\Http\Response|null
      */
-    public function deleteBulk()
+    public function deleteBulk(): ?Response
     {
         $this->request->allowMethod(['post']);
 
@@ -244,9 +251,9 @@ class FileStorageController extends FileStorageAppController
      * GET → renders the form (and a dry-run preview if `model` query is set).
      * POST → executes the cleanup against the resolved scope.
      *
-     * @return \Cake\Http\Response|null|void
+     * @return \Cake\Http\Response|null
      */
-    public function cleanup()
+    public function cleanup(): ?Response
     {
         $service = new CleanupService();
 
@@ -282,6 +289,8 @@ class FileStorageController extends FileStorageAppController
         }
 
         $this->set(compact('models', 'report', 'previewModel', 'previewCollection'));
+
+        return null;
     }
 
     /**
@@ -295,7 +304,7 @@ class FileStorageController extends FileStorageAppController
      *
      * @return \Cake\Http\Response|null
      */
-    public function regenerateVariants($id = null)
+    public function regenerateVariants(?string $id = null): ?Response
     {
         $this->request->allowMethod(['post']);
 
@@ -349,7 +358,7 @@ class FileStorageController extends FileStorageAppController
      *
      * @return \Cake\Http\Response
      */
-    public function download($id = null)
+    public function download(?string $id = null): Response
     {
         $entity = $this->FileStorage->get($id);
         $variant = (string)$this->request->getQuery('variant', '');

--- a/src/Controller/Admin/FileStorageDashboardController.php
+++ b/src/Controller/Admin/FileStorageDashboardController.php
@@ -3,6 +3,7 @@
 namespace FileStorage\Controller\Admin;
 
 use Cake\Core\Plugin;
+use Cake\Http\Response;
 use FileStorage\Model\Table\FileStorageTable;
 
 class FileStorageDashboardController extends FileStorageAppController
@@ -25,9 +26,9 @@ class FileStorageDashboardController extends FileStorageAppController
     }
 
     /**
-     * @return \Cake\Http\Response|null|void
+     * @return \Cake\Http\Response|null
      */
-    public function index()
+    public function index(): ?Response
     {
         $totalCount = $this->FileStorage->find()->count();
 
@@ -124,5 +125,7 @@ class FileStorageDashboardController extends FileStorageAppController
             'recent',
         ));
         $this->set('queueLoaded', Plugin::isLoaded('Queue'));
+
+        return null;
     }
 }

--- a/src/Model/Behavior/FileAssociationBehavior.php
+++ b/src/Model/Behavior/FileAssociationBehavior.php
@@ -131,7 +131,7 @@ class FileAssociationBehavior extends Behavior
      *
      * @return void
      */
-    protected function processOne(EntityInterface $entity, string $assocName, array $assocConfig)
+    protected function processOne(EntityInterface $entity, string $assocName, array $assocConfig): void
     {
         $property = $assocConfig['property'];
 
@@ -168,7 +168,7 @@ class FileAssociationBehavior extends Behavior
      *
      * @return void
      */
-    protected function processMany(EntityInterface $entity, string $assocName, array $assocConfig)
+    protected function processMany(EntityInterface $entity, string $assocName, array $assocConfig): void
     {
         $property = $assocConfig['property'];
 

--- a/src/Model/Behavior/FileStorageBehavior.php
+++ b/src/Model/Behavior/FileStorageBehavior.php
@@ -204,10 +204,17 @@ class FileStorageBehavior extends Behavior
                 if (empty($tableConfig['className'])) {
                     $tableConfig['className'] = 'FileStorage.FileStorage';
                 }
-                // Temporarily remove behavior to prevent recursion when saving metadata
+                // Temporarily remove behavior to prevent recursion when saving metadata.
+                // try/finally so that even if saveOrFail() throws (and the outer catch
+                // deletes the entity + rethrows), the table doesn't end up permanently
+                // missing this behavior — the TableLocator can cache the same instance
+                // across the rest of the request.
                 $this->table()->removeBehavior('FileStorage');
-                $this->table()->saveOrFail($entity, ['checkRules' => false]);
-                $this->table()->addBehavior('FileStorage', $tableConfig);
+                try {
+                    $this->table()->saveOrFail($entity, ['checkRules' => false]);
+                } finally {
+                    $this->table()->addBehavior('FileStorage', $tableConfig);
+                }
             } catch (Throwable $exception) {
                 $this->table()->delete($entity);
 
@@ -332,7 +339,7 @@ class FileStorageBehavior extends Behavior
      *
      * @return \Cake\Datasource\EntityInterface
      */
-    public function fileObjectToEntity(FileInterface $file, ?EntityInterface $entity)
+    public function fileObjectToEntity(FileInterface $file, ?EntityInterface $entity): EntityInterface
     {
         return $this->getTransformer()->fileObjectToEntity($file, $entity);
     }

--- a/src/Model/Validation/ImageValidationTrait.php
+++ b/src/Model/Validation/ImageValidationTrait.php
@@ -17,12 +17,12 @@ trait ImageValidationTrait
      *
      * @return bool Success
      */
-    public static function isValidImage($check, array $allowedTypes = []): bool
+    public static function isValidImage(UploadedFileInterface|array $check, array $allowedTypes = []): bool
     {
         if ($check instanceof UploadedFileInterface) {
             $file = $check->getStream()->getMetadata('uri');
         } else {
-            if (!isset($check['tmp_name']) || !strlen($check['tmp_name'])) {
+            if (($check['tmp_name'] ?? '') === '') {
                 return false;
             }
             $file = $check['tmp_name'];
@@ -48,13 +48,13 @@ trait ImageValidationTrait
      *
      * @return bool Success
      */
-    public static function isAboveMinWidth($check, int $width): bool
+    public static function isAboveMinWidth(UploadedFileInterface|array $check, int $width): bool
     {
         if ($check instanceof UploadedFileInterface) {
             $file = $check->getStream()->getMetadata('uri');
         } else {
             // Non-file uploads also mean the height is too big
-            if (!isset($check['tmp_name']) || !strlen($check['tmp_name'])) {
+            if (($check['tmp_name'] ?? '') === '') {
                 return false;
             }
             $file = $check['tmp_name'];
@@ -75,13 +75,13 @@ trait ImageValidationTrait
      *
      * @return bool Success
      */
-    public static function isBelowMaxWidth($check, int $width): bool
+    public static function isBelowMaxWidth(UploadedFileInterface|array $check, int $width): bool
     {
         if ($check instanceof UploadedFileInterface) {
             $file = $check->getStream()->getMetadata('uri');
         } else {
             // Non-file uploads also mean the height is too big
-            if (!isset($check['tmp_name']) || !strlen($check['tmp_name'])) {
+            if (($check['tmp_name'] ?? '') === '') {
                 return false;
             }
 
@@ -103,13 +103,13 @@ trait ImageValidationTrait
      *
      * @return bool Success
      */
-    public static function isAboveMinHeight($check, int $height): bool
+    public static function isAboveMinHeight(UploadedFileInterface|array $check, int $height): bool
     {
         if ($check instanceof UploadedFileInterface) {
             $file = $check->getStream()->getMetadata('uri');
         } else {
             // Non-file uploads also mean the height is too big
-            if (!isset($check['tmp_name']) || !strlen($check['tmp_name'])) {
+            if (($check['tmp_name'] ?? '') === '') {
                 return false;
             }
             $file = $check['tmp_name'];
@@ -130,13 +130,13 @@ trait ImageValidationTrait
      *
      * @return bool Success
      */
-    public static function isBelowMaxHeight($check, int $height): bool
+    public static function isBelowMaxHeight(UploadedFileInterface|array $check, int $height): bool
     {
         if ($check instanceof UploadedFileInterface) {
             $file = $check->getStream()->getMetadata('uri');
         } else {
             // Non-file uploads also mean the height is too big
-            if (!isset($check['tmp_name']) || !strlen($check['tmp_name'])) {
+            if (($check['tmp_name'] ?? '') === '') {
                 return false;
             }
             $file = $check['tmp_name'];

--- a/src/Model/Validation/UploadValidationTrait.php
+++ b/src/Model/Validation/UploadValidationTrait.php
@@ -15,7 +15,7 @@ trait UploadValidationTrait
      *
      * @return bool Success
      */
-    public static function isUnderPhpSizeLimit($check): bool
+    public static function isUnderPhpSizeLimit(UploadedFileInterface|array $check): bool
     {
         if ($check instanceof UploadedFileInterface) {
             return $check->getError() !== UPLOAD_ERR_INI_SIZE;
@@ -32,7 +32,7 @@ trait UploadValidationTrait
      *
      * @return bool Success
      */
-    public static function isUnderFormSizeLimit($check): bool
+    public static function isUnderFormSizeLimit(UploadedFileInterface|array $check): bool
     {
         if ($check instanceof UploadedFileInterface) {
             return $check->getError() !== UPLOAD_ERR_FORM_SIZE;
@@ -48,7 +48,7 @@ trait UploadValidationTrait
      *
      * @return bool Success
      */
-    public static function isCompletedUpload($check): bool
+    public static function isCompletedUpload(UploadedFileInterface|array $check): bool
     {
         if ($check instanceof UploadedFileInterface) {
             return $check->getError() !== UPLOAD_ERR_PARTIAL;
@@ -64,7 +64,7 @@ trait UploadValidationTrait
      *
      * @return bool Success
      */
-    public static function isFileUpload($check): bool
+    public static function isFileUpload(UploadedFileInterface|array $check): bool
     {
         if ($check instanceof UploadedFileInterface) {
             return $check->getError() !== UPLOAD_ERR_NO_FILE;
@@ -80,7 +80,7 @@ trait UploadValidationTrait
      *
      * @return bool Success
      */
-    public static function isSuccessfulWrite($check): bool
+    public static function isSuccessfulWrite(UploadedFileInterface|array $check): bool
     {
         if ($check instanceof UploadedFileInterface) {
             return $check->getError() !== UPLOAD_ERR_CANT_WRITE;
@@ -97,7 +97,7 @@ trait UploadValidationTrait
      *
      * @return bool Success
      */
-    public static function isAboveMinSize($check, $size): bool
+    public static function isAboveMinSize(UploadedFileInterface|array $check, int $size): bool
     {
         if ($check instanceof UploadedFileInterface) {
             return $check->getSize() >= $size;
@@ -114,7 +114,7 @@ trait UploadValidationTrait
      *
      * @return bool Success
      */
-    public static function isBelowMaxSize($check, $size): bool
+    public static function isBelowMaxSize(UploadedFileInterface|array $check, int $size): bool
     {
         if ($check instanceof UploadedFileInterface) {
             return $check->getSize() <= $size;
@@ -134,7 +134,7 @@ trait UploadValidationTrait
      *
      * @return bool
      */
-    public static function hasAllowedExtension($check, array $extensions): bool
+    public static function hasAllowedExtension(UploadedFileInterface|array $check, array $extensions): bool
     {
         if (!$extensions) {
             return false;
@@ -173,7 +173,7 @@ trait UploadValidationTrait
      *
      * @return bool
      */
-    public static function hasAllowedMimeType($check, array $mimes, bool $sniff = true): bool
+    public static function hasAllowedMimeType(UploadedFileInterface|array $check, array $mimes, bool $sniff = true): bool
     {
         if (!$mimes) {
             return false;

--- a/tests/TestCase/Utility/SignedUrlGeneratorTest.php
+++ b/tests/TestCase/Utility/SignedUrlGeneratorTest.php
@@ -61,9 +61,9 @@ class SignedUrlGeneratorTest extends TestCase
         $this->assertIsArray($result);
         $this->assertArrayHasKey('signature', $result);
         $this->assertArrayHasKey('expires', $result);
-        $this->assertEquals($expires, $result['expires']);
+        $this->assertSame($expires, $result['expires']);
         $this->assertIsString($result['signature']);
-        $this->assertEquals(64, strlen($result['signature'])); // SHA256 hex = 64 chars
+        $this->assertSame(64, strlen($result['signature'])); // SHA256 hex = 64 chars
     }
 
     /**
@@ -135,7 +135,7 @@ class SignedUrlGeneratorTest extends TestCase
             'secret' => 'configured-secret',
         ]);
 
-        $this->assertEquals($expected['signature'], $result['signature']);
+        $this->assertSame($expected['signature'], $result['signature']);
 
         Configure::delete('FileStorage.signatureSecret');
     }

--- a/tests/TestCase/View/Helper/ImageHelperTest.php
+++ b/tests/TestCase/View/Helper/ImageHelperTest.php
@@ -82,10 +82,10 @@ class ImageHelperTest extends FileStorageTestCase
         ]);
 
         $result = $this->helper->imageUrl($image, 't150', ['pathPrefix' => 'src/']);
-        $this->assertEquals('/src/test/path/testimage.c3f33c2a.jpg', $result);
+        $this->assertSame('/src/test/path/testimage.c3f33c2a.jpg', $result);
 
         $result = $this->helper->imageUrl($image, null, ['pathPrefix' => 'src/']);
-        $this->assertEquals('/src/test/path/testimage.jpg', $result);
+        $this->assertSame('/src/test/path/testimage.jpg', $result);
     }
 
     /**


### PR DESCRIPTION
## Summary

Type tightening, recursion-guard hardening, doc note. All small, mostly mechanical.

### Native union types on validators

`UploadedFileInterface|array $check` on every public static method on `UploadValidationTrait` and `ImageValidationTrait`, replacing the previous untyped `$check` (only documented in PHPDoc). `int $size` on `isAboveMinSize` / `isBelowMaxSize` (was untyped). PHP 8.2 supports the union everywhere.

### Drop the `isset(...) || !strlen(...)` cloak

`ImageValidationTrait` had five identical sites of the form

```php
if (!isset($check['tmp_name']) || !strlen($check['tmp_name'])) {
    return false;
}
```

Replaced with `($check['tmp_name'] ?? '') === ''` — same semantics, no double-bookkeeping of a missing key vs an empty string.

### Concrete return type on `fileObjectToEntity`

`ImageVariantGenerateCommand::fileObjectToEntity()` and `FileStorageBehavior::fileObjectToEntity()` now declare `: EntityInterface` to match the existing `@return EntityInterface` docblock.

### `try/finally` around the FileStorageBehavior recursion guard

`FileStorageBehavior::afterSave()` removes the FileStorage behavior before calling `saveOrFail()` to prevent recursion, then re-adds it. If `saveOrFail()` throws, the outer catch deletes the entity and rethrows — but the table object would have stayed permanently behavior-less for the rest of the request, since the TableLocator caches the same instance. Wrap the save in `try/finally` so `addBehavior()` always runs even on the throw path.

### Type the admin controller actions

`index(): ?Response`, `view(?string $id = null): ?Response`, `edit(...): ?Response`, `delete(...): ?Response`, `deleteBulk(): ?Response`, `cleanup(): ?Response`, `regenerateVariants(?string $id = null): ?Response`. Same on `FileStorageDashboardController::index()`. Methods that didn't return now `return null;` explicitly so the typed signature holds.

### `: void` on FileAssociationBehavior

`processOne()` and `processMany()` already had `@return void` in their docblocks but no native return type. Added.

### `assertEquals` → `assertSame` on scalars

`SignedUrlGeneratorTest` and `ImageHelperTest` had a few `assertEquals` calls comparing scalar strings/ints; switched to `assertSame` so they check type as well as value.

### README note on FileStorage primary keys

Documented that callers should not pre-fill the `id` on a FileStorage entity before save — the UUID-based path strategy in `php-collective/file-storage` would race on a pre-set id under concurrent stores.

## Verification

- `vendor/bin/phpunit` — 86 tests, 221 assertions, all green.
- `vendor/bin/phpstan analyze` — clean.
- `vendor/bin/phpcs` — clean.
