### PR TITLE
Use plugin-specific i18n domain for translations

### DIFF
--- a/resources/locales/file_storage.pot
+++ b/resources/locales/file_storage.pot
@@ -1,0 +1,408 @@
+# LANGUAGE translation of CakePHP Application
+# Copyright YEAR NAME <EMAIL@ADDRESS>
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PROJECT VERSION\n"
+"POT-Creation-Date: 2026-05-04 03:32+0200\n"
+"PO-Revision-Date: YYYY-mm-DD HH:MM+ZZZZ\n"
+"Last-Translator: NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <EMAIL@ADDRESS>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=INTEGER; plural=EXPRESSION;\n"
+
+msgid "Dry-Run only."
+msgstr ""
+
+msgid "Cannot find variants config for this model/collection."
+msgstr ""
+
+msgid "No images found for this model/collection"
+msgstr ""
+
+msgid "{0} image file(s) will be processed"
+msgstr ""
+
+msgid "- ID {0} processed"
+msgstr ""
+
+msgid "Command for (re)generating image variants."
+msgstr ""
+
+msgid "The storage table for image processing you want to use."
+msgstr ""
+
+msgid "Limits the amount of records to be processed in one batch"
+msgstr ""
+
+msgid "The adapter config name to use."
+msgstr ""
+
+msgid "Force regeneration of variants even if they already exist."
+msgstr ""
+
+msgid "Model name of the images to generate"
+msgstr ""
+
+msgid "Collection name of the images to generate."
+msgstr ""
+
+msgid "The image variant (omit for all). Careful: This currently wipes the other variants."
+msgstr ""
+
+msgid "The file storage has been saved."
+msgstr ""
+
+msgid "The file storage could not be saved. Please, try again."
+msgstr ""
+
+msgid "The file storage has been deleted."
+msgstr ""
+
+msgid "The file storage could not be deleted. Please, try again."
+msgstr ""
+
+msgid "No file storage entries selected."
+msgstr ""
+
+msgid "{0} deleted, {1} failed."
+msgstr ""
+
+msgid "Bulk delete failed."
+msgstr ""
+
+msgid "Cleanup complete: {0} orphaned files deleted, {1} orphaned rows removed."
+msgstr ""
+
+msgid "Variant regeneration job has been queued for {0}."
+msgstr ""
+
+msgid "File is not stored on any adapter."
+msgstr ""
+
+msgid "No path stored for the requested file."
+msgstr ""
+
+msgid "FileStorage adapter not configured."
+msgstr ""
+
+msgid "Backing file is missing on the adapter."
+msgstr ""
+
+msgid "{0} file storage entry deleted."
+msgid_plural "{0} file storage entries deleted."
+msgstr[0] ""
+msgstr[1] ""
+
+msgid "Cleanup"
+msgstr ""
+
+msgid "Storage Cleanup"
+msgstr ""
+
+msgid "Scope"
+msgstr ""
+
+msgid "Model"
+msgstr ""
+
+msgid "— all —"
+msgstr ""
+
+msgid "Collection"
+msgstr ""
+
+msgid "(leave empty for all)"
+msgstr ""
+
+msgid "Preview (dry-run)"
+msgstr ""
+
+msgid "Dry-run report"
+msgstr ""
+
+msgid "Checked {0} rows"
+msgstr ""
+
+msgid "Orphan rows (would delete)"
+msgstr ""
+
+msgid "Orphan files on disk (would delete)"
+msgstr ""
+
+msgid "Rows with missing backing files"
+msgstr ""
+
+msgid "Show {0} orphan file paths"
+msgstr ""
+
+msgid "Show {0} rows with missing files"
+msgstr ""
+
+msgid "Row id"
+msgstr ""
+
+msgid "Missing variants"
+msgstr ""
+
+msgid "Run cleanup now"
+msgstr ""
+
+msgid "Sure? This permanently deletes the orphan rows and files listed above."
+msgstr ""
+
+msgid "Nothing to clean up — storage is in sync."
+msgstr ""
+
+msgid "Actions"
+msgstr ""
+
+msgid "Delete"
+msgstr ""
+
+msgid "Are you sure you want to delete # {0}?"
+msgstr ""
+
+msgid "List File Storage"
+msgstr ""
+
+msgid "File Storage"
+msgstr ""
+
+msgid "Edit File Storage"
+msgstr ""
+
+msgid "Submit"
+msgstr ""
+
+msgid "Files"
+msgstr ""
+
+msgid "Filters"
+msgstr ""
+
+msgid "active"
+msgstr ""
+
+msgid "Mime prefix"
+msgstr ""
+
+msgid "Filename contains"
+msgstr ""
+
+msgid "substring match"
+msgstr ""
+
+msgid "FK"
+msgstr ""
+
+msgid "id"
+msgstr ""
+
+msgid "Min size (MB)"
+msgstr ""
+
+msgid "Created from"
+msgstr ""
+
+msgid "Created to"
+msgstr ""
+
+msgid "Filter"
+msgstr ""
+
+msgid "Reset"
+msgstr ""
+
+msgid "Delete the selected file storage entries? This cannot be undone."
+msgstr ""
+
+msgid "Delete selected"
+msgstr ""
+
+msgid "Tip: tick the header checkbox to select all rows on this page."
+msgstr ""
+
+msgid "Select all"
+msgstr ""
+
+msgid "Select row"
+msgstr ""
+
+msgid "View"
+msgstr ""
+
+msgid "Download"
+msgstr ""
+
+msgid "Edit"
+msgstr ""
+
+msgid "Queue variant regeneration"
+msgstr ""
+
+msgid "Queue a variant regeneration job for {0}?"
+msgstr ""
+
+msgid "Install dereuromark/cakephp-queue to enable background variant regeneration."
+msgstr ""
+
+msgid "Delete {0}?"
+msgstr ""
+
+msgid "previous"
+msgstr ""
+
+msgid "next"
+msgstr ""
+
+msgid "File"
+msgstr ""
+
+msgid "Back to list"
+msgstr ""
+
+msgid "Regenerate variants"
+msgstr ""
+
+msgid "Delete {0}? This cannot be undone."
+msgstr ""
+
+msgid "Details"
+msgstr ""
+
+msgid "Mime / Extension"
+msgstr ""
+
+msgid "Adapter"
+msgstr ""
+
+msgid "Path"
+msgstr ""
+
+msgid "DB filesize"
+msgstr ""
+
+msgid "bytes"
+msgstr ""
+
+msgid "Hash"
+msgstr ""
+
+msgid "Created"
+msgstr ""
+
+msgid "Modified"
+msgstr ""
+
+msgid "User"
+msgstr ""
+
+msgid "Variants"
+msgstr ""
+
+msgid "Preview"
+msgstr ""
+
+msgid "Variant"
+msgstr ""
+
+msgid "Size on disk"
+msgstr ""
+
+msgid "State"
+msgstr ""
+
+msgid "main"
+msgstr ""
+
+msgid "present"
+msgstr ""
+
+msgid "missing"
+msgstr ""
+
+msgid "Open inline"
+msgstr ""
+
+msgid "no path"
+msgstr ""
+
+msgid "No variants generated."
+msgstr ""
+
+msgid "Variants (raw)"
+msgstr ""
+
+msgid "Metadata"
+msgstr ""
+
+msgid "Dashboard"
+msgstr ""
+
+msgid "FileStorage Dashboard"
+msgstr ""
+
+msgid "Total Files"
+msgstr ""
+
+msgid "Total Size"
+msgstr ""
+
+msgid "Orphan Rows"
+msgstr ""
+
+msgid "Adapters"
+msgstr ""
+
+msgid "Top Collections"
+msgstr ""
+
+msgid "Size"
+msgstr ""
+
+msgid "No data."
+msgstr ""
+
+msgid "Top Models"
+msgstr ""
+
+msgid "Files by Adapter"
+msgstr ""
+
+msgid "Top Mime Types"
+msgstr ""
+
+msgid "Mime"
+msgstr ""
+
+msgid "Largest Files"
+msgstr ""
+
+msgid "Filename"
+msgstr ""
+
+msgid "Recent Uploads"
+msgstr ""
+
+msgid "No uploads yet."
+msgstr ""
+
+msgid "Install {0} to enable background image-variant regeneration from this UI."
+msgstr ""
+
+msgid "Navigation"
+msgstr ""
+
+msgid "Background Jobs"
+msgstr ""
+
+msgid "Queue Admin"
+msgstr ""
+
+msgid "Queue (not loaded)"
+msgstr ""
+

--- a/src/Command/CleanupCommand.php
+++ b/src/Command/CleanupCommand.php
@@ -56,7 +56,7 @@ class CleanupCommand extends Command
         $parser->addArgument('collection');
         $parser->addOption('dryRun', [
             'short' => 'd',
-            'help' => __('Dry-Run only.'),
+            'help' => __d('file_storage', 'Dry-Run only.'),
             'boolean' => true,
         ]);
 

--- a/src/Command/ImageVariantGenerateCommand.php
+++ b/src/Command/ImageVariantGenerateCommand.php
@@ -97,7 +97,7 @@ class ImageVariantGenerateCommand extends Command
         }
 
         if (!$operations) {
-            $io->abort(__('Cannot find variants config for this model/collection.'));
+            $io->abort(__d('file_storage', 'Cannot find variants config for this model/collection.'));
         }
 
         // Wrap operations in proper structure for processing
@@ -132,12 +132,12 @@ class ImageVariantGenerateCommand extends Command
                 $totalImageCount = $this->_getCount($model, $collection);
 
                 if ($totalImageCount === 0) {
-                    $io->out(__('No images found for this model/collection'));
+                    $io->out(__d('file_storage', 'No images found for this model/collection'));
 
                     continue;
                 }
 
-                $io->out(__('{0} image file(s) will be processed', $totalImageCount));
+                $io->out(__d('file_storage', '{0} image file(s) will be processed', $totalImageCount));
 
                 $options = $args->getOptions();
                 $this->_loop($io, $model, $collection, $variants, $options);
@@ -188,7 +188,7 @@ class ImageVariantGenerateCommand extends Command
                         $this->_processEntity($image, $operations, $options);
                     }
 
-                    $io->verbose(__('- ID {0} processed', $image->id));
+                    $io->verbose(__d('file_storage', '- ID {0} processed', $image->id));
                 }
             }
             $offset += $limit;
@@ -293,32 +293,32 @@ class ImageVariantGenerateCommand extends Command
     {
         $parser = parent::getOptionParser();
         $parser->setDescription([
-            __('Command for (re)generating image variants.'),
+            __d('file_storage', 'Command for (re)generating image variants.'),
         ]);
         $parser->addOption('storage', [
             'short' => 's',
-            'help' => __('The storage table for image processing you want to use.'),
+            'help' => __d('file_storage', 'The storage table for image processing you want to use.'),
             'default' => 'FileStorage.FileStorage',
         ]);
         $parser->addOption('limit', [
             'short' => 'l',
-            'help' => __('Limits the amount of records to be processed in one batch'),
+            'help' => __d('file_storage', 'Limits the amount of records to be processed in one batch'),
         ]);
         $parser->addOption('dryRun', [
             'short' => 'd',
-            'help' => __('Dry-Run only.'),
+            'help' => __d('file_storage', 'Dry-Run only.'),
             'boolean' => true,
         ]);
         $parser->addOptions(
             [
                 'adapter' => [
                     'short' => 'a',
-                    'help' => __('The adapter config name to use.'),
+                    'help' => __d('file_storage', 'The adapter config name to use.'),
                     'default' => 'Local',
                 ],
                 'force' => [
                     'short' => 'f',
-                    'help' => __('Force regeneration of variants even if they already exist.'),
+                    'help' => __d('file_storage', 'Force regeneration of variants even if they already exist.'),
                     'boolean' => true,
                 ],
             ],
@@ -326,15 +326,15 @@ class ImageVariantGenerateCommand extends Command
         $parser->addArguments(
             [
                 'model' => [
-                    'help' => __('Model name of the images to generate'),
+                    'help' => __d('file_storage', 'Model name of the images to generate'),
                     'required' => false,
                 ],
                 'collection' => [
-                    'help' => __('Collection name of the images to generate.'),
+                    'help' => __d('file_storage', 'Collection name of the images to generate.'),
                     'required' => false,
                 ],
                 'variant' => [
-                    'help' => __('The image variant (omit for all). Careful: This currently wipes the other variants.'),
+                    'help' => __d('file_storage', 'The image variant (omit for all). Careful: This currently wipes the other variants.'),
                     'required' => false,
                 ],
             ],

--- a/src/Controller/Admin/FileStorageController.php
+++ b/src/Controller/Admin/FileStorageController.php
@@ -156,11 +156,11 @@ class FileStorageController extends FileStorageAppController
         if ($this->request->is(['patch', 'post', 'put'])) {
             $fileStorage = $this->FileStorage->patchEntity($fileStorage, $this->request->getData());
             if ($this->FileStorage->save($fileStorage)) {
-                $this->Flash->success(__('The file storage has been saved.'));
+                $this->Flash->success(__d('file_storage', 'The file storage has been saved.'));
 
                 return $this->redirect(['action' => 'index']);
             }
-            $this->Flash->error(__('The file storage could not be saved. Please, try again.'));
+            $this->Flash->error(__d('file_storage', 'The file storage could not be saved. Please, try again.'));
         }
         $this->set(compact('fileStorage'));
 
@@ -178,9 +178,9 @@ class FileStorageController extends FileStorageAppController
         $fileStorage = $this->FileStorage->get($id);
         $redirect = $this->request->getQuery('redirect');
         if ($this->FileStorage->delete($fileStorage)) {
-            $this->Flash->success(__('The file storage has been deleted.'));
+            $this->Flash->success(__d('file_storage', 'The file storage has been deleted.'));
         } else {
-            $this->Flash->error(__('The file storage could not be deleted. Please, try again.'));
+            $this->Flash->error(__d('file_storage', 'The file storage could not be deleted. Please, try again.'));
         }
 
         if ($redirect === 'ref') {
@@ -208,7 +208,7 @@ class FileStorageController extends FileStorageAppController
         $ids = array_values(array_filter($ids, static fn ($id): bool => (string)$id !== ''));
 
         if (!$ids) {
-            $this->Flash->warning(__('No file storage entries selected.'));
+            $this->Flash->warning(__d('file_storage', 'No file storage entries selected.'));
 
             return $this->redirect(['action' => 'index']);
         }
@@ -230,16 +230,17 @@ class FileStorageController extends FileStorageAppController
         }
 
         if ($deleted > 0 && $failed === 0) {
-            $this->Flash->success(__n(
+            $this->Flash->success(__dn(
+                'file_storage',
                 '{0} file storage entry deleted.',
                 '{0} file storage entries deleted.',
                 $deleted,
                 $deleted,
             ));
         } elseif ($deleted > 0 && $failed > 0) {
-            $this->Flash->warning(__('{0} deleted, {1} failed.', $deleted, $failed));
+            $this->Flash->warning(__d('file_storage', '{0} deleted, {1} failed.', $deleted, $failed));
         } else {
-            $this->Flash->error(__('Bulk delete failed.'));
+            $this->Flash->error(__d('file_storage', 'Bulk delete failed.'));
         }
 
         return $this->redirect(['action' => 'index']);
@@ -272,7 +273,8 @@ class FileStorageController extends FileStorageAppController
             $collection = (string)$this->request->getData('collection') ?: null;
             $report = $service->run($model, $collection, dryRun: false);
 
-            $this->Flash->success(__(
+            $this->Flash->success(__d(
+                'file_storage',
                 'Cleanup complete: {0} orphaned files deleted, {1} orphaned rows removed.',
                 count($report->deletedFiles),
                 $report->deletedRows,
@@ -335,7 +337,7 @@ class FileStorageController extends FileStorageAppController
             ],
         );
 
-        $this->Flash->success(__('Variant regeneration job has been queued for {0}.', h($entity->filename)));
+        $this->Flash->success(__d('file_storage', 'Variant regeneration job has been queued for {0}.', h($entity->filename)));
 
         return $this->redirect($this->referer(['action' => 'index']));
     }


### PR DESCRIPTION
## Summary

- Convert 31 `__()` calls and 1 `__n()` call in `src/` to `__d('file_storage', ...)` / `__dn('file_storage', ...)`. The 142 pre-existing `__d('file_storage', ...)` calls already pointed at the right domain — the rest of the plugin now matches.
- Add `resources/locales/file_storage.pot` (130 unique msgids) generated via `bin/cake i18n extract` so language packs can be derived from a stable POT.

## Why

Most plugin strings already used `__d('file_storage', ...)`, but a chunk in the admin command and the cleanup-redirect controller still used bare `__()`, so those strings landed in the host app's `default` domain instead of the plugin's. Anyone building a German/Japanese/etc. language pack from the existing POT would have been missing every CLI message and ~30 admin-UI strings.

## Verification (local)

- phpunit: 93 / 93
- phpstan: no errors
- phpcs: clean