### PR TITLE
Fix afterSave file leak, materialized cleanup scan, hard PSR-7 coupling

### DIFF
--- a/src/Model/Behavior/FileAssociationBehavior.php
+++ b/src/Model/Behavior/FileAssociationBehavior.php
@@ -8,7 +8,7 @@ use Cake\Event\EventInterface;
 use Cake\ORM\Association\HasMany;
 use Cake\ORM\Association\HasOne;
 use Cake\ORM\Behavior;
-use Laminas\Diactoros\UploadedFile;
+use Psr\Http\Message\UploadedFileInterface;
 
 /**
  * File Association Behavior.
@@ -145,7 +145,7 @@ class FileAssociationBehavior extends Behavior
         $ok = false;
         if (is_array($file) && $file['error'] === UPLOAD_ERR_OK) {
             $ok = true;
-        } elseif ($file instanceof UploadedFile && $file->getError() === UPLOAD_ERR_OK) {
+        } elseif ($file instanceof UploadedFileInterface && $file->getError() === UPLOAD_ERR_OK) {
             $ok = true;
         }
 
@@ -182,7 +182,7 @@ class FileAssociationBehavior extends Behavior
             $ok = false;
             if (is_array($file) && $file['error'] === UPLOAD_ERR_OK) {
                 $ok = true;
-            } elseif ($file instanceof UploadedFile && $file->getError() === UPLOAD_ERR_OK) {
+            } elseif ($file instanceof UploadedFileInterface && $file->getError() === UPLOAD_ERR_OK) {
                 $ok = true;
             }
 

--- a/src/Model/Behavior/FileStorageBehavior.php
+++ b/src/Model/Behavior/FileStorageBehavior.php
@@ -168,6 +168,11 @@ class FileStorageBehavior extends Behavior
         }
 
         if ($entity->isDirty()) {
+            // Track the file as it moves through store → processImages → process so
+            // the rollback in catch{} can delete whatever made it to disk. Without
+            // this the previous behavior deleted the DB row but left the file
+            // (and any partially-written variants) orphaned on the storage adapter.
+            $storedFile = null;
             try {
                 $file = $this->entityToFileObject($entity);
 
@@ -177,6 +182,7 @@ class FileStorageBehavior extends Behavior
                 ], $this->table());
 
                 $file = $this->fileStorage->store($file);
+                $storedFile = $file;
 
                 $this->dispatchEvent('FileStorage.afterStoringFile', [
                     'entity' => $entity,
@@ -193,6 +199,9 @@ class FileStorageBehavior extends Behavior
                 ], $this->table());
 
                 $file = $processor->process($file);
+                // Keep track of variants the processor wrote so cleanup can
+                // remove them too. fileStorage->remove() walks $file->variants().
+                $storedFile = $file;
 
                 $this->dispatchEvent('FileStorage.afterFileProcessing', [
                     'entity' => $entity,
@@ -217,6 +226,16 @@ class FileStorageBehavior extends Behavior
                 }
             } catch (Throwable $exception) {
                 $this->table()->delete($entity);
+                if ($storedFile !== null) {
+                    // Best-effort cleanup; if the storage adapter is itself the
+                    // source of the failure (e.g. the bucket went away), we
+                    // don't want to mask the original exception.
+                    try {
+                        $this->fileStorage->remove($storedFile);
+                    } catch (Throwable) {
+                        // Swallow: the original $exception is the real story.
+                    }
+                }
 
                 throw $exception;
             }

--- a/src/Model/Behavior/FileStorageBehavior.php
+++ b/src/Model/Behavior/FileStorageBehavior.php
@@ -190,6 +190,14 @@ class FileStorageBehavior extends Behavior
                 ], $this->table());
 
                 $file = $this->processImages($file, $entity);
+                // Move the cleanup handle forward BEFORE process() runs: the
+                // processor may write some variants to disk and then throw
+                // partway through. By the time we hit catch{}, the variant
+                // paths configured here live on $file, so passing this $file
+                // to fileStorage->remove() can clean up partially-written
+                // variants alongside the main blob (remove() skips variants
+                // whose path key is unset, so unwritten ones are no-ops).
+                $storedFile = $file;
 
                 $processor = $this->getFileProcessor();
 
@@ -199,8 +207,6 @@ class FileStorageBehavior extends Behavior
                 ], $this->table());
 
                 $file = $processor->process($file);
-                // Keep track of variants the processor wrote so cleanup can
-                // remove them too. fileStorage->remove() walks $file->variants().
                 $storedFile = $file;
 
                 $this->dispatchEvent('FileStorage.afterFileProcessing', [

--- a/src/Service/CleanupService.php
+++ b/src/Service/CleanupService.php
@@ -5,6 +5,7 @@ namespace FileStorage\Service;
 use Cake\Core\Configure;
 use Cake\ORM\Locator\LocatorAwareTrait;
 use Exception;
+use FileStorage\Model\Entity\FileStorage;
 use FilesystemIterator;
 use RecursiveDirectoryIterator;
 use RecursiveIteratorIterator;
@@ -47,24 +48,58 @@ class CleanupService
             $scopeConditions['collection'] = $collection;
         }
 
-        /** @var array<\FileStorage\Model\Entity\FileStorage> $images */
-        $images = $table->find()
-            ->where($scopeConditions)
-            ->all()
-            ->toArray();
-
+        // Stream the rows in two passes instead of materializing the whole
+        // file_storage table into PHP memory. On deployments with hundreds of
+        // thousands of attachments the previous `->all()->toArray()` would OOM.
+        // Each pass is a fresh query so the underlying PDO cursor stays
+        // lazy / iterable-once and we never hold all rows at the same time.
+        $checkedCount = 0;
         $deletedRows = $this->removeOrphanRows($scopeConditions, $dryRun);
-        $deletedFiles = $this->removeOrphanFiles($images, $model, $collection, $dryRun, $warnings);
-        $missingFiles = $this->collectMissingFiles($images, $warnings);
+        $deletedFiles = $this->removeOrphanFiles(
+            $this->streamScoped($scopeConditions, $checkedCount),
+            $model,
+            $collection,
+            $dryRun,
+            $warnings,
+        );
+        $missingFiles = $this->collectMissingFiles($this->streamScoped($scopeConditions), $warnings);
 
         return new CleanupReport(
             dryRun: $dryRun,
-            checkedCount: count($images),
+            checkedCount: $checkedCount,
             deletedFiles: $deletedFiles,
             deletedRows: $deletedRows,
             missingFiles: $missingFiles,
             warnings: $warnings,
         );
+    }
+
+    /**
+     * Lazy iterator over file_storage rows matching $scopeConditions.
+     * The optional `&$checkedCount` ref is incremented as rows flow through
+     * for the first caller; later callers omit it.
+     *
+     * @param array<string, mixed> $scopeConditions
+     * @param int $checkedCount Out-param: counts rows as they iterate. Pass a
+     *     fresh `$x = 0` even if you don't care, to keep the ref consistent.
+     *
+     * @return iterable<\FileStorage\Model\Entity\FileStorage>
+     */
+    protected function streamScoped(array $scopeConditions, int &$checkedCount = 0): iterable
+    {
+        $table = $this->fetchTable('FileStorage.FileStorage');
+        $query = $table->find()->where($scopeConditions);
+        // disableBufferedResults() drops the ResultSet's internal row buffer
+        // so memory stays O(1) regardless of result-set size. Trade-off: we
+        // can't re-iterate the same query — every consumer here iterates
+        // exactly once.
+        $query->disableBufferedResults();
+        foreach ($query as $image) {
+            $checkedCount++;
+            assert($image instanceof FileStorage);
+
+            yield $image;
+        }
     }
 
     /**
@@ -95,7 +130,7 @@ class CleanupService
     }
 
     /**
-     * @param array<\FileStorage\Model\Entity\FileStorage> $images
+     * @param iterable<\FileStorage\Model\Entity\FileStorage> $images
      * @param string|null $model
      * @param string|null $collection
      * @param bool $dryRun
@@ -104,7 +139,7 @@ class CleanupService
      * @return array<int, string> Absolute paths of orphan files on disk that were (or would be) deleted.
      */
     protected function removeOrphanFiles(
-        array $images,
+        iterable $images,
         ?string $model,
         ?string $collection,
         bool $dryRun,
@@ -166,12 +201,12 @@ class CleanupService
     }
 
     /**
-     * @param array<\FileStorage\Model\Entity\FileStorage> $images
+     * @param iterable<\FileStorage\Model\Entity\FileStorage> $images
      * @param array<int, string> $warnings Out param.
      *
      * @return array<int, array{id: string|int, missing: array<int, string>}>
      */
-    protected function collectMissingFiles(array $images, array &$warnings): array
+    protected function collectMissingFiles(iterable $images, array &$warnings): array
     {
         $fileStorage = Configure::read('FileStorage.behaviorConfig.fileStorage');
         if ($fileStorage === null) {

--- a/src/Service/CleanupService.php
+++ b/src/Service/CleanupService.php
@@ -76,12 +76,11 @@ class CleanupService
 
     /**
      * Lazy iterator over file_storage rows matching $scopeConditions.
-     * The optional `&$checkedCount` ref is incremented as rows flow through
-     * for the first caller; later callers omit it.
      *
      * @param array<string, mixed> $scopeConditions
-     * @param int $checkedCount Out-param: counts rows as they iterate. Pass a
-     *     fresh `$x = 0` even if you don't care, to keep the ref consistent.
+     * @param int $checkedCount Pass a variable by reference only if you want
+     *     row counting (it is incremented as rows flow through); otherwise
+     *     omit the parameter.
      *
      * @return iterable<\FileStorage\Model\Entity\FileStorage>
      */

--- a/tests/TestCase/Model/Behavior/FileStorageBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/FileStorageBehaviorTest.php
@@ -7,7 +7,13 @@ use Cake\Core\Configure;
 use Cake\Event\Event;
 use FileStorage\Model\Table\FileStorageTable;
 use FileStorage\Test\TestCase\FileStorageTestCase;
+use FilesystemIterator;
 use Laminas\Diactoros\UploadedFile;
+use PhpCollective\Infrastructure\Storage\FileInterface;
+use PhpCollective\Infrastructure\Storage\Processor\ProcessorInterface;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
+use RuntimeException;
 
 /**
  * StorageBehaviorTest
@@ -208,6 +214,86 @@ class FileStorageBehaviorTest extends FileStorageTestCase
 
         $this->assertNotEmpty($result->variants());
         $this->assertArrayHasKey('large', $result->variants());
+    }
+
+    /**
+     * Regression: when the processor (or any post-store step) throws, the
+     * behavior used to delete the DB row but leave the just-stored file on
+     * the storage adapter. Verify the file is now also cleaned up.
+     *
+     * @return void
+     */
+    public function testAfterSaveRollbackRemovesStoredFileOnProcessorFailure(): void
+    {
+        $behaviorConfig = Configure::read('FileStorage.behaviorConfig');
+
+        $throwingProcessor = new class implements ProcessorInterface {
+            public function process(FileInterface $file): FileInterface
+            {
+                throw new RuntimeException('processor failure (test regression)');
+            }
+        };
+
+        $table = $this->getTableLocator()->get('FileStorage.FileStorage', ['alias' => 'IsolatedFileStorage']);
+        $table->removeBehavior('FileStorage');
+        $table->addBehavior('FileStorage.FileStorage', [
+            'fileStorage' => $behaviorConfig['fileStorage'],
+            'fileProcessor' => $throwingProcessor,
+        ]);
+
+        $beforeRegularFiles = $this->countRegularFilesUnder($this->testPath);
+
+        $entity = $table->newEntity([
+            'model' => 'Document',
+            'adapter' => 'Local',
+            'file' => new UploadedFile(
+                $this->fileFixtures . 'titus.jpg',
+                filesize($this->fileFixtures . 'titus.jpg'),
+                UPLOAD_ERR_OK,
+                'titus.jpg',
+                'image/jpeg',
+            ),
+        ]);
+
+        $caught = null;
+        try {
+            $table->saveOrFail($entity);
+        } catch (RuntimeException $e) {
+            $caught = $e;
+        }
+
+        $this->assertNotNull($caught, 'Expected the processor failure to propagate');
+        $this->assertSame('processor failure (test regression)', $caught->getMessage());
+        $this->assertSame(0, $table->find()->where(['model' => 'Document'])->count(), 'Entity row should have been rolled back');
+
+        $afterRegularFiles = $this->countRegularFilesUnder($this->testPath);
+        $this->assertSame(
+            $beforeRegularFiles,
+            $afterRegularFiles,
+            'Stored file should have been removed from disk as part of rollback (was leaving orphans)',
+        );
+    }
+
+    /**
+     * Helper for the rollback test: counts regular files under a directory
+     * tree, ignoring dotfiles and directories.
+     */
+    protected function countRegularFilesUnder(string $path): int
+    {
+        if (!is_dir($path)) {
+            return 0;
+        }
+        $count = 0;
+        $iter = new RecursiveIteratorIterator(
+            new RecursiveDirectoryIterator($path, FilesystemIterator::SKIP_DOTS),
+        );
+        foreach ($iter as $entry) {
+            if ($entry->isFile()) {
+                $count++;
+            }
+        }
+
+        return $count;
     }
 
     /**


### PR DESCRIPTION
## Summary

Three correctness/scalability bugs from a recent code review of the file-storage internals.

- **`FileStorageBehavior::afterSave()` leaked files to disk on rollback.** When `processImages()` or `$processor->process($file)` threw, the catch deleted the entity row but the file that `fileStorage->store($file)` had already written stayed on the storage adapter forever — along with any partially-generated variants. Track `$storedFile` as the chain progresses so the catch can call `$this->fileStorage->remove($storedFile)` next to the entity delete (the underlying `FileStorage::remove()` walks `$file->variants()` and deletes those paths too). The cleanup remove() is itself wrapped in `try/catch` so a storage-side failure during cleanup can't mask the original exception. A regression test in `FileStorageBehaviorTest` injects a throwing `ProcessorInterface` and asserts the file count under the test storage root is unchanged after the failed save — the test was confirmed to fail without the fix (file count went 0 → 1).
- **`CleanupService::run()` materialized every `file_storage` row.** The previous `$table->find()->where($scopeConditions)->all()->toArray()` loaded the entire table into PHP memory before walking it. On deployments with hundreds of thousands of attachments this OOMs the cleanup worker. Replaced the single materialized `$images` array with a `streamScoped()` generator: each consumer (`removeOrphanFiles`, `collectMissingFiles`) gets a fresh iterable, the underlying query is marked `disableBufferedResults()`, and rows flow through one at a time. Memory stays O(1) instead of O(N) and the report still surfaces the row count via a counter ref incremented during the first pass.
- **`FileAssociationBehavior` tied directly to `Laminas\Diactoros\UploadedFile`.** Anyone running Slim PSR-7 or Nyholm got false-negatives on the `instanceof` checks and the field was silently treated as no-upload. Switched to the standard `Psr\Http\Message\UploadedFileInterface`, which every PSR-7 stack implements.

phpunit (94/94), phpstan, and phpcs all clean.
