### PR TITLE
Add signed-URL serving action and url() helper

### DIFF
--- a/docs/Documentation/FileServing.md
+++ b/docs/Documentation/FileServing.md
@@ -294,28 +294,50 @@ Signed URLs allow temporary access to files without authentication, useful for:
 - API integrations
 - Temporary downloads
 
-### Generating Signed URLs
+### Built-in signed-URL serving (recommended)
+
+The plugin ships a public action at `/file-storage/signed/{id}/{signature}` that verifies the signature, looks up the file, and streams it directly. For local-filesystem adapters it uses `Response::withFile()`, giving HTTP `Range` support for `<video>` and `<audio>` elements for free; non-local adapters fall back to a single `read()` + string body.
+
+**Generate the URL** with the one-call helper:
 
 ```php
 use FileStorage\Utility\SignedUrlGenerator;
 
-// In your controller
+$url = SignedUrlGenerator::url($fileStorage, [
+    'expires' => strtotime('+24 hours'),
+    'fullBase' => true, // absolute URL for email
+]);
+// → http://example.com/file-storage/signed/<id>/<sha256>?expires=1799999999
+```
+
+The helper places the signature in the path segment (so reverse-proxy access logs that scrub query strings don't shred half the credential) and `expires` in the query string. The matching action handles:
+
+- 404 for unknown id
+- 403 for tampered or expired signatures (same status either way so probing callers can't distinguish)
+- 404 if the backing file disappeared from the adapter
+
+If `Authentication` is loaded globally, the `signed` action calls `allowUnauthenticated('signed')` on initialize so the request doesn't get bounced to the login form — that's the entire authorization story for a signed URL.
+
+### Custom serving controller (for app-specific authorization)
+
+You can still ship your own controller when you need extra checks beyond signature verification (rate limiting, audit logs, header tweaks). Generate the signature with `SignedUrlGenerator::generate()` and route it however you like:
+
+```php
+use FileStorage\Utility\SignedUrlGenerator;
+
 public function share($fileStorageId)
 {
     $fileStorageTable = $this->fetchTable('FileStorage.FileStorage');
     $fileStorage = $fileStorageTable->get($fileStorageId);
 
-    // Check user can share this file
     if (!$this->_checkAccess($fileStorage)) {
         throw new ForbiddenException();
     }
 
-    // Generate signature valid for 24 hours
     $signatureData = SignedUrlGenerator::generate($fileStorage, [
         'expires' => strtotime('+24 hours'),
     ]);
 
-    // Generate full URL with signature
     $url = Router::url([
         'controller' => 'Files',
         'action' => 'serve',
@@ -324,7 +346,6 @@ public function share($fileStorageId)
         '_full' => true,
     ]);
 
-    // Email or display URL
     $this->set('shareUrl', $url);
 }
 ```

--- a/src/Controller/FileStorageController.php
+++ b/src/Controller/FileStorageController.php
@@ -1,0 +1,213 @@
+<?php declare(strict_types=1);
+
+namespace FileStorage\Controller;
+
+use Cake\Controller\Controller;
+use Cake\Core\Configure;
+use Cake\Http\Exception\BadRequestException;
+use Cake\Http\Exception\ForbiddenException;
+use Cake\Http\Exception\InternalErrorException;
+use Cake\Http\Exception\NotFoundException;
+use Cake\Http\Response;
+use FileStorage\Model\Entity\FileStorage;
+use FileStorage\Utility\SignedUrlGenerator;
+use League\Flysystem\Local\LocalFilesystemAdapter;
+use ReflectionClass;
+
+/**
+ * Public-facing controller for signed-URL file downloads.
+ *
+ * Pairs with `SignedUrlGenerator` to consume time-limited share links
+ * without authenticating the visitor: anyone holding a valid signature
+ * can fetch the file until the embedded expiration passes (or the file's
+ * `modified` timestamp changes, which invalidates the signature
+ * implicitly per `SignedUrlGenerator::generate()`).
+ *
+ * Use case examples:
+ *
+ * - email a download link to a customer
+ * - embed a video tag pointing at a non-public S3 bucket
+ * - generate "magic links" to PDF invoices from API integrations
+ *
+ * Not for authenticated downloads — those go through the
+ * `Admin\FileStorageController::download()` action which checks ACLs.
+ */
+class FileStorageController extends Controller
+{
+ /**
+  * Authentication / authorization plugins typically register their components
+  * via `AppController::initialize()`. We skip both here — the *whole point*
+  * of a signed URL is to authorize anonymously via a presented signature.
+  * Apps that load Authentication/Authorization globally should add this
+  * action to their allow-list (typically by name in an `Allow` config).
+  *
+  * @return void
+  */
+    public function initialize(): void
+    {
+        parent::initialize();
+        if (!$this->components()->has('Authentication')) {
+            return;
+        }
+        $authentication = $this->components()->get('Authentication');
+        if (method_exists($authentication, 'allowUnauthenticated')) {
+            $authentication->allowUnauthenticated(['signed']);
+        }
+    }
+
+    /**
+     * Stream a file via a signed URL.
+     *
+     * URL: `/file-storage/signed/{id}/{signature}?expires={timestamp}`
+     *
+     * The signature must match what `SignedUrlGenerator::generate()` produced
+     * for this entity with the same `expires` (if any). Mismatched signatures
+     * 403; expired signatures 403; unknown ids 404; valid signatures whose
+     * backing file disappeared on the adapter 404.
+     *
+     * For local-filesystem adapters the response uses `Response::withFile()`,
+     * which gives HTTP `Range` support for free — important for `<video>` and
+     * `<audio>` elements that send a Range header on first byte. For
+     * non-local adapters (S3, etc.) we read the bytes once and emit them
+     * with `Response::withStringBody()`; clients fall back to plain GET.
+     *
+     * @param string|int|null $id File storage row id.
+     * @param string|null $signature URL-supplied signature.
+     *
+     * @throws \Cake\Http\Exception\BadRequestException
+     * @throws \Cake\Http\Exception\ForbiddenException
+     * @throws \Cake\Http\Exception\NotFoundException
+     *
+     * @return \Cake\Http\Response
+     */
+    public function signed($id = null, ?string $signature = null): Response
+    {
+        if ($id === null || $id === '' || $signature === null || $signature === '') {
+            throw new BadRequestException('Missing id or signature.');
+        }
+
+        /** @var \FileStorage\Model\Table\FileStorageTable $table */
+        $table = $this->fetchTable('FileStorage.FileStorage');
+
+        /** @var \FileStorage\Model\Entity\FileStorage|null $entity */
+        $entity = $table->find()->where(['FileStorage.id' => $id])->first();
+        if ($entity === null) {
+            throw new NotFoundException('File not found.');
+        }
+
+        $expires = $this->getRequest()->getQuery('expires');
+        $options = [];
+        if ($expires !== null) {
+            $options['expires'] = (int)$expires;
+        }
+
+        if (!SignedUrlGenerator::verify($entity, $signature, $options)) {
+            // Same status for "wrong signature" and "expired" so a probing
+            // caller can't distinguish — the next-best outcome would be
+            // 401, but that implies a way to authenticate, which signed
+            // URLs don't have. 403 is the conventional choice.
+            throw new ForbiddenException('Invalid or expired signature.');
+        }
+
+        return $this->streamEntity($entity);
+    }
+
+    /**
+     * Resolve the storage adapter for this entity and stream its contents.
+     *
+     * @param \FileStorage\Model\Entity\FileStorage $entity
+     *
+     * @throws \Cake\Http\Exception\InternalErrorException
+     * @throws \Cake\Http\Exception\NotFoundException
+     *
+     * @return \Cake\Http\Response
+     */
+    protected function streamEntity(FileStorage $entity): Response
+    {
+        $path = $entity->path;
+        if (!$path) {
+            throw new NotFoundException('No path stored for the requested file.');
+        }
+
+        $fileStorage = Configure::read('FileStorage.behaviorConfig.fileStorage');
+        if ($fileStorage === null) {
+            throw new InternalErrorException('FileStorage adapter not configured.');
+        }
+
+        $adapter = $fileStorage->getStorage((string)$entity->adapter);
+        if (!$adapter->fileExists($path)) {
+            throw new NotFoundException('Backing file is missing on the adapter.');
+        }
+
+        $mime = (string)$entity->mime_type !== ''
+            ? (string)$entity->mime_type
+            : 'application/octet-stream';
+        $filename = (string)$entity->filename;
+        $disposition = 'inline; filename="' . str_replace('"', '', $filename) . '"';
+
+        // Local adapter exposes a real filesystem path; use withFile() so we
+        // get range-request handling, Last-Modified, and ETag essentially
+        // for free. Non-local adapters (S3, FTP, custom) only expose a
+        // `read()` API, so we materialize the bytes once into the response.
+        $localPath = $this->resolveLocalPath($adapter, $path);
+        if ($localPath !== null) {
+            $response = $this->response
+                ->withFile($localPath, ['name' => $filename])
+                ->withType($mime)
+                ->withHeader('Content-Disposition', $disposition);
+
+            return $response;
+        }
+
+        return $this->response
+            ->withType($mime)
+            ->withHeader('Content-Disposition', $disposition)
+            ->withStringBody($adapter->read($path));
+    }
+
+    /**
+     * If the storage adapter is local, reach into it via its public
+     * `prefixPath()` semantics to compute a real on-disk path. League's
+     * `LocalFilesystemAdapter` doesn't expose that directly, but its
+     * constructor stores the root and we can ask Flysystem to translate the
+     * logical path via `prefixPath()` reflection — that's the supported
+     * way to bridge to `withFile()`.
+     *
+     * Returns null for any non-local adapter so the caller falls back to
+     * `read()` + string body.
+     *
+     * @param object $adapter Flysystem adapter instance.
+     * @param string $relativePath
+     *
+     * @return string|null Absolute on-disk path, or null if the adapter
+     *     isn't local-filesystem-backed.
+     */
+    protected function resolveLocalPath(object $adapter, string $relativePath): ?string
+    {
+        if (!$adapter instanceof LocalFilesystemAdapter) {
+            return null;
+        }
+
+        // LocalFilesystemAdapter stores its prefixed pather as a private
+        // property; the supported way to reach it is via reflection or by
+        // keeping the root alongside the adapter at construction time.
+        // The plugin's StorageService configures the adapter with a known
+        // `root`, so we read that back via reflection — same approach the
+        // CleanupService uses elsewhere in the plugin.
+        $ref = new ReflectionClass($adapter);
+        if (!$ref->hasProperty('prefixer')) {
+            return null;
+        }
+        $prop = $ref->getProperty('prefixer');
+        $prefixer = $prop->getValue($adapter);
+        if (!is_object($prefixer) || !method_exists($prefixer, 'prefixPath')) {
+            return null;
+        }
+        $absolute = $prefixer->prefixPath($relativePath);
+        if (!is_string($absolute) || !is_file($absolute) || !is_readable($absolute)) {
+            return null;
+        }
+
+        return $absolute;
+    }
+}

--- a/src/Controller/FileStorageController.php
+++ b/src/Controller/FileStorageController.php
@@ -83,7 +83,7 @@ class FileStorageController extends Controller
     public function signed($id = null, ?string $signature = null): Response
     {
         if ($id === null || $id === '' || $signature === null || $signature === '') {
-            throw new BadRequestException('Missing id or signature.');
+            throw new BadRequestException(__d('file_storage', 'Missing id or signature.'));
         }
 
         /** @var \FileStorage\Model\Table\FileStorageTable $table */
@@ -92,7 +92,7 @@ class FileStorageController extends Controller
         /** @var \FileStorage\Model\Entity\FileStorage|null $entity */
         $entity = $table->find()->where(['FileStorage.id' => $id])->first();
         if ($entity === null) {
-            throw new NotFoundException('File not found.');
+            throw new NotFoundException(__d('file_storage', 'File not found.'));
         }
 
         $expires = $this->getRequest()->getQuery('expires');
@@ -106,7 +106,7 @@ class FileStorageController extends Controller
             // caller can't distinguish — the next-best outcome would be
             // 401, but that implies a way to authenticate, which signed
             // URLs don't have. 403 is the conventional choice.
-            throw new ForbiddenException('Invalid or expired signature.');
+            throw new ForbiddenException(__d('file_storage', 'Invalid or expired signature.'));
         }
 
         return $this->streamEntity($entity);
@@ -124,19 +124,23 @@ class FileStorageController extends Controller
      */
     protected function streamEntity(FileStorage $entity): Response
     {
+        if (!$entity->adapter) {
+            throw new NotFoundException(__d('file_storage', 'File is not stored on any adapter.'));
+        }
+
         $path = $entity->path;
         if (!$path) {
-            throw new NotFoundException('No path stored for the requested file.');
+            throw new NotFoundException(__d('file_storage', 'No path stored for the requested file.'));
         }
 
         $fileStorage = Configure::read('FileStorage.behaviorConfig.fileStorage');
         if ($fileStorage === null) {
-            throw new InternalErrorException('FileStorage adapter not configured.');
+            throw new InternalErrorException(__d('file_storage', 'FileStorage adapter not configured.'));
         }
 
         $adapter = $fileStorage->getStorage((string)$entity->adapter);
         if (!$adapter->fileExists($path)) {
-            throw new NotFoundException('Backing file is missing on the adapter.');
+            throw new NotFoundException(__d('file_storage', 'Backing file is missing on the adapter.'));
         }
 
         $mime = (string)$entity->mime_type !== ''
@@ -166,12 +170,13 @@ class FileStorageController extends Controller
     }
 
     /**
-     * If the storage adapter is local, reach into it via its public
-     * `prefixPath()` semantics to compute a real on-disk path. League's
-     * `LocalFilesystemAdapter` doesn't expose that directly, but its
-     * constructor stores the root and we can ask Flysystem to translate the
-     * logical path via `prefixPath()` reflection — that's the supported
-     * way to bridge to `withFile()`.
+     * If the storage adapter is local, reach into its private `prefixer`
+     * (PathPrefixer) via reflection to compute a real on-disk path so we
+     * can hand a filesystem path to `Response::withFile()` and get HTTP
+     * Range support for free. Flysystem's `LocalFilesystemAdapter` does
+     * not expose this publicly; this is a deliberate, narrow internal
+     * lookup that degrades to null on any mismatch (callers then fall
+     * back to `read()` + string body).
      *
      * Returns null for any non-local adapter so the caller falls back to
      * `read()` + string body.
@@ -188,12 +193,13 @@ class FileStorageController extends Controller
             return null;
         }
 
-        // LocalFilesystemAdapter stores its prefixed pather as a private
-        // property; the supported way to reach it is via reflection or by
-        // keeping the root alongside the adapter at construction time.
-        // The plugin's StorageService configures the adapter with a known
-        // `root`, so we read that back via reflection — same approach the
-        // CleanupService uses elsewhere in the plugin.
+        // LocalFilesystemAdapter stores its `prefixer` (PathPrefixer) as a
+        // private property and exposes no public accessor. Flysystem itself
+        // is consistent about this across 2.x/3.x, but the property name is
+        // technically an implementation detail — if it ever changes we
+        // simply fall back to the read()+string-body path below, which is
+        // why this method returns null on any structural mismatch instead
+        // of erroring.
         $ref = new ReflectionClass($adapter);
         if (!$ref->hasProperty('prefixer')) {
             return null;

--- a/src/FileStoragePlugin.php
+++ b/src/FileStoragePlugin.php
@@ -46,6 +46,19 @@ class FileStoragePlugin extends BasePlugin
                 $routes->fallbacks();
             });
         });
+
+        // Public signed-download route. Lives outside the Admin prefix because
+        // it authorizes via the embedded signature, not via an authenticated
+        // session. The signature is captured as a URL segment (not a query
+        // string) so it doesn't get scrubbed from same-origin Referer headers
+        // or hidden in reverse-proxy access logs that strip the query.
+        $routes->plugin('FileStorage', ['path' => '/file-storage'], function (RouteBuilder $routes): void {
+            $routes->connect(
+                '/signed/{id}/{signature}',
+                ['controller' => 'FileStorage', 'action' => 'signed'],
+                ['pass' => ['id', 'signature'], 'signature' => '[a-f0-9]{64}'],
+            );
+        });
     }
 
     /**

--- a/src/Utility/SignedUrlGenerator.php
+++ b/src/Utility/SignedUrlGenerator.php
@@ -3,6 +3,7 @@
 namespace FileStorage\Utility;
 
 use Cake\Core\Configure;
+use Cake\Routing\Router;
 use Cake\Utility\Security;
 use FileStorage\Model\Entity\FileStorage;
 
@@ -79,5 +80,47 @@ class SignedUrlGenerator
 
         // Timing-safe comparison to prevent timing attacks
         return hash_equals((string)$expected['signature'], $signature);
+    }
+
+    /**
+     * Build a fully-routable signed-download URL for this entity.
+     *
+     * Pairs with `FileStorage\Controller\FileStorageController::signed()`.
+     * The returned URL embeds the signature in the path segment and the
+     * expiration in the query string so reverse-proxy access logs scrub
+     * the secret half (signature) less aggressively than they would
+     * scrub a `?signature=...` query parameter — but the signature alone
+     * is useless without the entity-derived data this class hashes into
+     * `generate()`, so log exposure is bounded.
+     *
+     * Set `'fullBase' => true` for an absolute URL (the common case for
+     * email links and external embeds); the default is a relative path
+     * suitable for same-origin templates.
+     *
+     * @param \FileStorage\Model\Entity\FileStorage $entity
+     * @param array<string, mixed> $options Forwarded to `generate()`, plus:
+     *     - `fullBase` (bool, default false): emit an absolute URL.
+     *
+     * @return string The signed URL.
+     */
+    public static function url(FileStorage $entity, array $options = []): string
+    {
+        $fullBase = (bool)($options['fullBase'] ?? false);
+        unset($options['fullBase']);
+
+        $signed = static::generate($entity, $options);
+        $url = [
+            'plugin' => 'FileStorage',
+            'prefix' => false,
+            'controller' => 'FileStorage',
+            'action' => 'signed',
+            $entity->id,
+            $signed['signature'],
+        ];
+        if ($signed['expires'] !== null) {
+            $url['?'] = ['expires' => $signed['expires']];
+        }
+
+        return Router::url($url, $fullBase);
     }
 }

--- a/tests/TestCase/Controller/FileStorageControllerTest.php
+++ b/tests/TestCase/Controller/FileStorageControllerTest.php
@@ -1,0 +1,160 @@
+<?php declare(strict_types=1);
+
+namespace FileStorage\Test\TestCase\Controller;
+
+use Cake\Http\Exception\BadRequestException;
+use Cake\Http\Exception\ForbiddenException;
+use Cake\Http\Exception\NotFoundException;
+use Cake\Http\ServerRequest;
+use Cake\TestSuite\IntegrationTestTrait;
+use Cake\Utility\Security;
+use FileStorage\Controller\FileStorageController;
+use FileStorage\Test\TestCase\FileStorageTestCase;
+use FileStorage\Utility\SignedUrlGenerator;
+
+/**
+ * @uses \FileStorage\Controller\FileStorageController
+ */
+class FileStorageControllerTest extends FileStorageTestCase
+{
+    use IntegrationTestTrait;
+
+    /**
+     * @return void
+     */
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->disableErrorHandlerMiddleware();
+        // SignedUrlGenerator falls back to Security::getSalt() if no
+        // FileStorage.signatureSecret is configured; the integration
+        // test harness doesn't auto-load app config, so set one here.
+        Security::setSalt('test-salt-for-file-storage-controller-tests-1234567890');
+    }
+
+    /**
+     * Valid signature → 200 with the actual file body.
+     *
+     * @return void
+     */
+    public function testSignedDeliversFileForValidSignature(): void
+    {
+        $mock = $this->_createMockFile('Item/cake.icon.png');
+        file_put_contents($mock, 'pretend-png-bytes');
+
+        $entity = $this->FileStorage->get(1);
+        $entity->adapter = 'Local';
+        $entity->path = 'Item/cake.icon.png';
+        $this->FileStorage->saveOrFail($entity);
+
+        $signed = SignedUrlGenerator::generate($entity);
+
+        $this->get([
+            'plugin' => 'FileStorage',
+            'prefix' => false,
+            'controller' => 'FileStorage',
+            'action' => 'signed',
+            $entity->id,
+            $signed['signature'],
+        ]);
+
+        $this->assertResponseOk();
+        $this->assertContentType('image/png');
+        // Body is served directly from disk via withFile() — assert presence of
+        // our payload bytes. The exact assertion shape here covers both the
+        // withFile() and withStringBody() code paths since both eventually
+        // emit the same bytes.
+        $this->assertResponseContains('pretend-png-bytes');
+    }
+
+    /**
+     * Tampered signature → 403.
+     *
+     * @return void
+     */
+    public function testSignedRejectsTamperedSignature(): void
+    {
+        $this->_createMockFile('Item/cake.icon.png');
+
+        $entity = $this->FileStorage->get(1);
+        $entity->adapter = 'Local';
+        $entity->path = 'Item/cake.icon.png';
+        $this->FileStorage->saveOrFail($entity);
+
+        $this->expectException(ForbiddenException::class);
+        $this->get([
+            'plugin' => 'FileStorage',
+            'prefix' => false,
+            'controller' => 'FileStorage',
+            'action' => 'signed',
+            $entity->id,
+            str_repeat('0', 64),
+        ]);
+    }
+
+    /**
+     * Expired signature → 403 (same status as tampered, so probing callers
+     * can't distinguish).
+     *
+     * @return void
+     */
+    public function testSignedRejectsExpiredSignature(): void
+    {
+        $this->_createMockFile('Item/cake.icon.png');
+
+        $entity = $this->FileStorage->get(1);
+        $entity->adapter = 'Local';
+        $entity->path = 'Item/cake.icon.png';
+        $this->FileStorage->saveOrFail($entity);
+
+        $signed = SignedUrlGenerator::generate($entity, ['expires' => time() - 60]);
+
+        $this->expectException(ForbiddenException::class);
+        $this->get([
+            'plugin' => 'FileStorage',
+            'prefix' => false,
+            'controller' => 'FileStorage',
+            'action' => 'signed',
+            $entity->id,
+            $signed['signature'],
+            '?' => ['expires' => $signed['expires']],
+        ]);
+    }
+
+    /**
+     * Unknown entity id → 404.
+     *
+     * @return void
+     */
+    public function testSignedRejectsUnknownId(): void
+    {
+        $this->expectException(NotFoundException::class);
+        $this->get([
+            'plugin' => 'FileStorage',
+            'prefix' => false,
+            'controller' => 'FileStorage',
+            'action' => 'signed',
+            99999,
+            str_repeat('a', 64),
+        ]);
+    }
+
+    /**
+     * Missing signature path segment is caught by the route regex; the
+     * controller's defence-in-depth check on null/empty also throws 400.
+     *
+     * @return void
+     */
+    public function testSignedRejectsEmptyArgsAsBadRequest(): void
+    {
+        $this->expectException(BadRequestException::class);
+
+        // Invoke the action directly with null args to exercise the guard
+        // — bypassing the router (the router regex would otherwise stop
+        // the request from even reaching the action).
+        $controller = new FileStorageController(
+            new ServerRequest(),
+        );
+        $controller->signed(null, null);
+    }
+}

--- a/tests/TestCase/Utility/SignedUrlGeneratorTest.php
+++ b/tests/TestCase/Utility/SignedUrlGeneratorTest.php
@@ -352,7 +352,7 @@ class SignedUrlGeneratorTest extends TestCase
     /**
      * Apply the plugin's routes() callback against the global router so the
      * `url()` lookups in tests have something to match against. Idempotent
-     * across tests — Router::reset() clears the scope.
+     * across tests — Router::reload() resets registered scopes/routes.
      */
     protected function loadPluginRoutes(): void
     {

--- a/tests/TestCase/Utility/SignedUrlGeneratorTest.php
+++ b/tests/TestCase/Utility/SignedUrlGeneratorTest.php
@@ -4,8 +4,10 @@ namespace FileStorage\Test\TestCase\Utility;
 
 use Cake\Core\Configure;
 use Cake\I18n\DateTime;
+use Cake\Routing\Router;
 use Cake\TestSuite\TestCase;
 use Cake\Utility\Security;
+use FileStorage\FileStoragePlugin;
 use FileStorage\Model\Entity\FileStorage;
 use FileStorage\Utility\SignedUrlGenerator;
 
@@ -301,5 +303,61 @@ class SignedUrlGeneratorTest extends TestCase
             ['secret' => 'wrong-secret'],
         );
         $this->assertFalse($isInvalid);
+    }
+
+    /**
+     * `url()` composes a path that round-trips back to the controller action
+     * via Cake's router. Signature lives in the path segment (not the query
+     * string) so reverse-proxy access logs that scrub query strings don't
+     * silently shred half the credential.
+     *
+     * @return void
+     */
+    public function testUrlPutsSignatureInPathAndExpiresInQuery(): void
+    {
+        $this->loadPluginRoutes();
+        $fileStorage = new FileStorage([
+            'id' => 'urn-test',
+            'path' => 'Item/file.png',
+            'modified' => new DateTime('2026-05-11 12:00:00'),
+        ]);
+
+        $url = SignedUrlGenerator::url($fileStorage, ['expires' => 1799999999]);
+
+        $this->assertStringContainsString('/file-storage/signed/urn-test/', $url);
+        $this->assertMatchesRegularExpression('#/[a-f0-9]{64}\b#', $url);
+        $this->assertStringContainsString('expires=1799999999', $url);
+    }
+
+    /**
+     * No `expires` option → no `expires` query string. Matches the
+     * `generate()` behavior of returning null when unspecified.
+     *
+     * @return void
+     */
+    public function testUrlWithoutExpiresLeavesQueryEmpty(): void
+    {
+        $this->loadPluginRoutes();
+        $fileStorage = new FileStorage([
+            'id' => 'urn-no-expiry',
+            'path' => 'Item/file.png',
+            'modified' => new DateTime('2026-05-11 12:00:00'),
+        ]);
+
+        $url = SignedUrlGenerator::url($fileStorage);
+
+        $this->assertStringNotContainsString('expires=', $url);
+    }
+
+    /**
+     * Apply the plugin's routes() callback against the global router so the
+     * `url()` lookups in tests have something to match against. Idempotent
+     * across tests — Router::reset() clears the scope.
+     */
+    protected function loadPluginRoutes(): void
+    {
+        Router::reload();
+        $builder = Router::createRouteBuilder('/');
+        (new FileStoragePlugin())->routes($builder);
     }
 }


### PR DESCRIPTION
## Summary

First of three strategic items from the audit — completes the signed-URL serving path.

The `SignedUrlGenerator` utility was already in the plugin but nothing consumed it. `generate()` / `verify()` worked in isolation, but there was no controller action or route to actually deliver a file when a caller presents a valid signature. This wires up the missing half.

## What's in

- **`FileStorage\Controller\FileStorageController::signed($id, $signature)`** — public, non-admin action. Verifies the signature against the entity (404 for unknown id, 403 for bad/expired signature, 404 again if the backing file disappeared on the adapter), then streams the file.
  - **Local-filesystem adapter:** response uses `Response::withFile()`, which gives HTTP `Range` support for free (Last-Modified + ETag too). Important for `<video>` / `<audio>` elements that send a Range header on first byte.
  - **Non-local adapters (S3, etc.):** fall through to `Response::withStringBody()` since they don't expose a real on-disk path. Clients gracefully fall back to plain GET.
- **`SignedUrlGenerator::url($entity, $options)`** — one-call API that builds a fully-routable signed URL. Signature lives in the path segment (so reverse-proxy access logs that scrub query strings don't shred half the credential); `expires` goes in the query string. `fullBase` option for absolute URLs in email links.
- **Route** registered in `FileStoragePlugin` under `/file-storage/signed/{id}/{signature}`, outside the Admin prefix. Signature is constrained to `[a-f0-9]{64}` matching the sha256 HMAC output.
- **`allowUnauthenticated('signed')` if Authentication is loaded** — the action is the entire authorization story for signed URLs, so it has to bypass session auth. `method_exists` guard keeps the static analyser happy when Authentication isn't installed.

## Use cases

- Email a download link to a customer (set `expires` to e.g. now + 7 days)
- Embed a `<video>` tag pointing at a non-public S3 bucket
- Generate "magic links" to PDF invoices from API integrations
- Time-limited shareable links to assets that normally require login

Not for authenticated downloads — those go through the existing `Admin\FileStorageController::download()` action which checks ACLs.

## Tests

Seven new tests across two files:

- `FileStorageControllerTest` (new) — five tests covering valid signature → 200 + body, tampered signature → 403, expired signature → 403, unknown id → 404, empty args → 400 (defense-in-depth).
- `SignedUrlGeneratorTest` — two new tests for `url()`: signature in path + expires in query, no `expires` ⇒ no query.

phpunit (101/101), phpstan, and phpcs all clean.
