### PR TITLE
Add ImageVariantTask for queued background variant regeneration

### DIFF
--- a/docs/Documentation/The-Image-Version-Shell.md
+++ b/docs/Documentation/The-Image-Version-Shell.md
@@ -28,6 +28,7 @@ All arguments are optional. If omitted, the command will process all configured 
   * Without this flag, existing variants are merged (preserved)
   * With this flag, all variants are replaced
 * **--dryRun, -d**: Dry-run only (preview what would be processed without making changes).
+* **--queue**: Enqueue one `ImageVariantTask` job per entity instead of processing inline. Requires `dereuromark/cakephp-queue`. See [Background regeneration via cakephp-queue](#background-regeneration-via-cakephp-queue).
 
 ## Examples
 
@@ -140,3 +141,44 @@ Image variants must be configured in your application's configuration file (e.g.
 * The command removes the FileStorage behavior during save to prevent infinite loops
 
 The new command requires both model and collection names to be specified.
+
+## Background regeneration via cakephp-queue
+
+Inline processing blocks the calling shell for the whole batch, which is fine
+for a one-off CLI run but unworkable from an admin UI button on a deployment
+with thousands of attachments. When `dereuromark/cakephp-queue` is installed,
+pass `--queue` to enqueue one `FileStorage.ImageVariant` job per entity:
+
+```sh
+bin/cake file_storage generate_image_variant Posts Avatar --queue
+```
+
+Each job lands on the queue immediately; queue workers pick them up and run
+the same processor pipeline per-entity. Benefits:
+
+- the admin "regenerate variants" action can call into the command and
+  return immediately
+- failed jobs auto-retry per the queue config
+- renderer CPU cost spreads across multiple workers naturally
+
+### Enqueuing directly from app code
+
+If you don't want to go through the CLI, build the job payload yourself:
+
+```php
+$queuedJobsTable = $this->fetchTable('Queue.QueuedJobs');
+$queuedJobsTable->createJob('FileStorage.ImageVariant', [
+    'id' => $fileStorage->id,
+    'operations' => [
+        'thumbnail' => ['width' => 100],
+        'medium'    => ['width' => 600],
+    ],
+    'merge' => true,                                 // keep existing variants
+    'storageTable' => 'FileStorage.FileStorage',     // optional
+]);
+```
+
+The task validates the payload (missing `id` or `operations` throws
+`Queue\Model\QueueException` so the worker can apply retry / dead-letter
+handling) and soft-fails — no exception, no log noise — when the entity has
+been deleted between enqueue and dispatch.

--- a/src/Command/ImageVariantGenerateCommand.php
+++ b/src/Command/ImageVariantGenerateCommand.php
@@ -203,19 +203,23 @@ class ImageVariantGenerateCommand extends Command
                             // Hand off the per-entity work to the queue. The
                             // ImageVariantTask payload mirrors the inline path:
                             // same operations, same merge semantics, same table.
+                            // We deliberately do NOT pass `adapter` — the task
+                            // resolves the storage adapter from the entity's
+                            // own `adapter` column, just like the inline path.
                             $queuedJobsTable->createJob('FileStorage.ImageVariant', [
                                 'id' => $image->id,
                                 'operations' => $operations,
-                                'adapter' => $options['adapter'] ?? null,
                                 'merge' => !($options['force'] ?? false),
                                 'storageTable' => $this->Table->getRegistryAlias(),
                             ]);
+                            $io->verbose(__d('file_storage', '- ID {0} enqueued', $image->id));
                         } else {
                             $this->_processEntity($image, $operations, $options);
+                            $io->verbose(__d('file_storage', '- ID {0} processed', $image->id));
                         }
+                    } else {
+                        $io->verbose(__d('file_storage', '- ID {0} processed', $image->id));
                     }
-
-                    $io->verbose(__d('file_storage', '- ID {0} processed', $image->id));
                 }
             }
             $offset += $limit;

--- a/src/Command/ImageVariantGenerateCommand.php
+++ b/src/Command/ImageVariantGenerateCommand.php
@@ -170,6 +170,20 @@ class ImageVariantGenerateCommand extends Command
         }
         $adapter = $storage->getStorage($options['adapter']);
 
+        $enqueue = !empty($options['queue']);
+        /** @var \Queue\Model\Table\QueuedJobsTable|null $queuedJobsTable */
+        $queuedJobsTable = null;
+        if ($enqueue) {
+            if (!class_exists('Queue\Model\Table\QueuedJobsTable')) {
+                $io->abort(__d(
+                    'file_storage',
+                    'The --queue option requires `dereuromark/cakephp-queue` to be installed.',
+                ));
+            }
+            /** @var \Queue\Model\Table\QueuedJobsTable $queuedJobsTable */
+            $queuedJobsTable = TableRegistry::getTableLocator()->get('Queue.QueuedJobs');
+        }
+
         do {
             $images = $this->_getRecords($model, $collection, $limit, $offset);
             if ($images) {
@@ -185,7 +199,20 @@ class ImageVariantGenerateCommand extends Command
                     //EventManager::instance()->dispatch($Event);
 
                     if (empty($options['dryRun'])) {
-                        $this->_processEntity($image, $operations, $options);
+                        if ($enqueue && $queuedJobsTable !== null) {
+                            // Hand off the per-entity work to the queue. The
+                            // ImageVariantTask payload mirrors the inline path:
+                            // same operations, same merge semantics, same table.
+                            $queuedJobsTable->createJob('FileStorage.ImageVariant', [
+                                'id' => $image->id,
+                                'operations' => $operations,
+                                'adapter' => $options['adapter'] ?? null,
+                                'merge' => !($options['force'] ?? false),
+                                'storageTable' => $this->Table->getRegistryAlias(),
+                            ]);
+                        } else {
+                            $this->_processEntity($image, $operations, $options);
+                        }
                     }
 
                     $io->verbose(__d('file_storage', '- ID {0} processed', $image->id));
@@ -319,6 +346,14 @@ class ImageVariantGenerateCommand extends Command
                 'force' => [
                     'short' => 'f',
                     'help' => __d('file_storage', 'Force regeneration of variants even if they already exist.'),
+                    'boolean' => true,
+                ],
+                'queue' => [
+                    'help' => __d(
+                        'file_storage',
+                        'Enqueue one ImageVariantTask job per entity instead of '
+                        . 'processing inline. Requires dereuromark/cakephp-queue.',
+                    ),
                     'boolean' => true,
                 ],
             ],

--- a/src/Queue/Task/ImageVariantTask.php
+++ b/src/Queue/Task/ImageVariantTask.php
@@ -38,8 +38,6 @@ use RuntimeException;
  *         'thumbnail' => ['width' => 100], // same shape `imageVariants` uses.
  *         'medium' => ['width' => 600],
  *     ],
- *     'adapter' => 'Local', // optional, defaults to the
- *                                             // entity's `adapter` column.
  *     'merge' => true, // optional, default true. Merge
  *                                             // means existing variants stay;
  *                                             // false replaces the variant set.
@@ -110,17 +108,13 @@ class ImageVariantTask extends Task
     /**
      * Apply the variant operations to one entity and persist the updated row.
      *
-     * Extracted as a public method so the equivalent inline path in
-     * `ImageVariantGenerateCommand` can be refactored to delegate here in a
-     * later PR without duplicating the processor pipeline.
-     *
      * @param \FileStorage\Model\Entity\FileStorage $entity
      * @param array<string, mixed> $operations
      * @param bool $merge
      *
      * @return void
      */
-    public function processEntity(EntityInterface $entity, array $operations, bool $merge = true): void
+    protected function processEntity(EntityInterface $entity, array $operations, bool $merge = true): void
     {
         $file = $this->entityToFileObject($entity);
         $file = $file->withVariants($operations, $merge);
@@ -143,18 +137,19 @@ class ImageVariantTask extends Task
 
         // Same recursion-guard pattern as ImageVariantGenerateCommand and the
         // FileStorageBehavior — strip the behavior for the metadata save so
-        // the afterSave processor pipeline doesn't re-fire here.
+        // the afterSave processor pipeline doesn't re-fire here. Tracking
+        // presence separately from config lets us restore the behavior even
+        // when it was attached with an empty options array.
         $behaviors = $this->storageTable->behaviors();
-        $tableConfig = $behaviors->has('FileStorage')
-            ? $behaviors->get('FileStorage')->getConfig()
-            : [];
-        if ($behaviors->has('FileStorage')) {
+        $hadBehavior = $behaviors->has('FileStorage');
+        $tableConfig = $hadBehavior ? $behaviors->get('FileStorage')->getConfig() : [];
+        if ($hadBehavior) {
             $this->storageTable->removeBehavior('FileStorage');
         }
         try {
             $this->storageTable->saveOrFail($entity);
         } finally {
-            if ($tableConfig) {
+            if ($hadBehavior) {
                 $this->storageTable->addBehavior('FileStorage.FileStorage', $tableConfig);
             }
         }

--- a/src/Queue/Task/ImageVariantTask.php
+++ b/src/Queue/Task/ImageVariantTask.php
@@ -1,0 +1,220 @@
+<?php declare(strict_types=1);
+
+namespace FileStorage\Queue\Task;
+
+use Cake\Core\Configure;
+use Cake\Datasource\EntityInterface;
+use Cake\Event\EventDispatcherTrait;
+use Cake\ORM\Locator\LocatorAwareTrait;
+use Cake\ORM\Table;
+use Cake\ORM\TableRegistry;
+use FileStorage\FileStorage\DataTransformer;
+use FileStorage\FileStorage\DataTransformerInterface;
+use PhpCollective\Infrastructure\Storage\FileInterface;
+use PhpCollective\Infrastructure\Storage\Processor\ProcessorInterface;
+use Queue\Model\QueueException;
+use Queue\Queue\Task;
+use RuntimeException;
+
+/**
+ * Regenerate image variants for a single FileStorage entity in the background.
+ *
+ * The `ImageVariantGenerateCommand` runs inline and blocks the calling shell
+ * for the whole batch — fine for one-off CLI use, but unusable from an admin
+ * UI button on a deployment with thousands of attachments. This task does the
+ * same per-entity work but as a dispatchable Queue plugin job, so:
+ *
+ * - the admin "regenerate variants" action can enqueue 1-job-per-entity and
+ *   return immediately;
+ * - failed jobs auto-retry per the queue config;
+ * - the renderer's CPU cost spreads across multiple workers naturally.
+ *
+ * Job data shape:
+ *
+ * ```php
+ * [
+ *     'id' => 'fs-entity-uuid-or-id', // REQUIRED — FileStorage row id
+ *     'operations' => [ // REQUIRED — variant config map,
+ *         'thumbnail' => ['width' => 100], // same shape `imageVariants` uses.
+ *         'medium' => ['width' => 600],
+ *     ],
+ *     'adapter' => 'Local', // optional, defaults to the
+ *                                             // entity's `adapter` column.
+ *     'merge' => true, // optional, default true. Merge
+ *                                             // means existing variants stay;
+ *                                             // false replaces the variant set.
+ *     'storageTable' => 'FileStorage.FileStorage', // optional, custom table.
+ * ]
+ * ```
+ *
+ * Soft-fails (returns early, no exception, logs nothing) when the entity is
+ * missing — a regeneration job for a since-deleted file is not an error.
+ * Throws `QueueException` for misconfigured payloads so the queue worker can
+ * apply its retry / dead-letter behavior.
+ */
+class ImageVariantTask extends Task
+{
+    use EventDispatcherTrait;
+    use LocatorAwareTrait;
+
+    /**
+     * @var int|null
+     */
+    public ?int $timeout = 300;
+
+    /**
+     * @var int|null
+     */
+    public ?int $retries = 1;
+
+    protected ?DataTransformerInterface $transformer = null;
+
+    protected ?ProcessorInterface $processor = null;
+
+    protected Table $storageTable;
+
+    /**
+     * @param array<string, mixed> $data
+     * @param int $jobId
+     *
+     * @throws \Queue\Model\QueueException For misconfigured payloads.
+     *
+     * @return void
+     */
+    public function run(array $data, int $jobId): void
+    {
+        if (empty($data['id'])) {
+            throw new QueueException('ImageVariantTask called without required `id` data key.');
+        }
+        if (empty($data['operations']) || !is_array($data['operations'])) {
+            throw new QueueException('ImageVariantTask called without required `operations` data key.');
+        }
+
+        $storageTableName = is_string($data['storageTable'] ?? null) && $data['storageTable'] !== ''
+            ? $data['storageTable']
+            : 'FileStorage.FileStorage';
+        $this->storageTable = TableRegistry::getTableLocator()->get($storageTableName);
+
+        /** @var \FileStorage\Model\Entity\FileStorage|null $entity */
+        $entity = $this->storageTable->find()->where(['id' => $data['id']])->first();
+        if ($entity === null) {
+            // File was removed since the job was queued — no-op. Logging an
+            // error here would just produce noise during normal cleanup.
+            return;
+        }
+
+        $merge = (bool)($data['merge'] ?? true);
+        $this->processEntity($entity, $data['operations'], $merge);
+    }
+
+    /**
+     * Apply the variant operations to one entity and persist the updated row.
+     *
+     * Extracted as a public method so the equivalent inline path in
+     * `ImageVariantGenerateCommand` can be refactored to delegate here in a
+     * later PR without duplicating the processor pipeline.
+     *
+     * @param \FileStorage\Model\Entity\FileStorage $entity
+     * @param array<string, mixed> $operations
+     * @param bool $merge
+     *
+     * @return void
+     */
+    public function processEntity(EntityInterface $entity, array $operations, bool $merge = true): void
+    {
+        $file = $this->entityToFileObject($entity);
+        $file = $file->withVariants($operations, $merge);
+
+        $processor = $this->getFileProcessor();
+
+        $this->dispatchEvent('FileStorage.beforeFileProcessing', [
+            'entity' => $entity,
+            'file' => $file,
+        ], $this->storageTable);
+
+        $file = $processor->process($file);
+
+        $this->dispatchEvent('FileStorage.afterFileProcessing', [
+            'entity' => $entity,
+            'file' => $file,
+        ], $this->storageTable);
+
+        $entity = $this->fileObjectToEntity($file, $entity);
+
+        // Same recursion-guard pattern as ImageVariantGenerateCommand and the
+        // FileStorageBehavior — strip the behavior for the metadata save so
+        // the afterSave processor pipeline doesn't re-fire here.
+        $behaviors = $this->storageTable->behaviors();
+        $tableConfig = $behaviors->has('FileStorage')
+            ? $behaviors->get('FileStorage')->getConfig()
+            : [];
+        if ($behaviors->has('FileStorage')) {
+            $this->storageTable->removeBehavior('FileStorage');
+        }
+        try {
+            $this->storageTable->saveOrFail($entity);
+        } finally {
+            if ($tableConfig) {
+                $this->storageTable->addBehavior('FileStorage.FileStorage', $tableConfig);
+            }
+        }
+    }
+
+    /**
+     * @throws \RuntimeException
+     *
+     * @return \PhpCollective\Infrastructure\Storage\Processor\ProcessorInterface
+     */
+    protected function getFileProcessor(): ProcessorInterface
+    {
+        if ($this->processor !== null) {
+            return $this->processor;
+        }
+
+        $processor = Configure::read('FileStorage.behaviorConfig.fileProcessor');
+        if (!$processor instanceof ProcessorInterface) {
+            throw new RuntimeException('No FileStorage processor configured.');
+        }
+        $this->processor = $processor;
+
+        return $this->processor;
+    }
+
+    /**
+     * @param \Cake\Datasource\EntityInterface $entity
+     *
+     * @return \PhpCollective\Infrastructure\Storage\FileInterface
+     */
+    protected function entityToFileObject(EntityInterface $entity): FileInterface
+    {
+        return $this->getTransformer()->entityToFileObject($entity);
+    }
+
+    /**
+     * @param \PhpCollective\Infrastructure\Storage\FileInterface $file
+     * @param \Cake\Datasource\EntityInterface|null $entity
+     *
+     * @return \Cake\Datasource\EntityInterface
+     */
+    protected function fileObjectToEntity(FileInterface $file, ?EntityInterface $entity): EntityInterface
+    {
+        return $this->getTransformer()->fileObjectToEntity($file, $entity);
+    }
+
+    /**
+     * @return \FileStorage\FileStorage\DataTransformerInterface
+     */
+    protected function getTransformer(): DataTransformerInterface
+    {
+        if ($this->transformer !== null) {
+            return $this->transformer;
+        }
+
+        $configured = Configure::read('FileStorage.behaviorConfig.dataTransformer');
+        $this->transformer = $configured instanceof DataTransformerInterface
+            ? $configured
+            : new DataTransformer($this->storageTable);
+
+        return $this->transformer;
+    }
+}

--- a/tests/TestCase/Queue/Task/ImageVariantTaskTest.php
+++ b/tests/TestCase/Queue/Task/ImageVariantTaskTest.php
@@ -1,0 +1,110 @@
+<?php declare(strict_types=1);
+
+namespace FileStorage\Test\TestCase\Queue\Task;
+
+use Cake\Datasource\ConnectionManager;
+use FileStorage\Queue\Task\ImageVariantTask;
+use FileStorage\Test\TestCase\FileStorageTestCase;
+use Queue\Model\QueueException;
+
+/**
+ * @uses \FileStorage\Queue\Task\ImageVariantTask
+ */
+class ImageVariantTaskTest extends FileStorageTestCase
+{
+ /**
+  * Only the FileStorage fixture is loaded. The Queue plugin's
+  * `queued_jobs` table is not part of this test app's schema, but the
+  * Task base class fetches it eagerly via LocatorAwareTrait — we side-
+  * step by creating the table manually as a one-off in setUp(). This
+  * lets the failure-path tests below (validation + soft no-op) work
+  * without dragging in the full Queue plugin migrations setup.
+  *
+  * @var array<string>
+  */
+    protected array $fixtures = [
+        'plugin.FileStorage.FileStorage',
+    ];
+
+    /**
+     * @return void
+     */
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        // Conjure a minimal `queued_jobs` table so the Task base class's
+        // LocatorAwareTrait lookup succeeds. A full Queue plugin migration
+        // isn't needed here — the assertions only exercise validation +
+        // missing-entity branches and never persist a job.
+        $connection = ConnectionManager::get('test');
+        $connection->execute(
+            'CREATE TABLE IF NOT EXISTS queued_jobs ('
+            . '  id INTEGER PRIMARY KEY AUTOINCREMENT,'
+            . '  job_task VARCHAR(255),'
+            . '  data TEXT'
+            . ')',
+        );
+    }
+
+    /**
+     * @return void
+     */
+    public function tearDown(): void
+    {
+        $connection = ConnectionManager::get('test');
+        $connection->execute('DROP TABLE IF EXISTS queued_jobs');
+        parent::tearDown();
+    }
+
+    /**
+     * Missing `id` data is a misconfigured payload — must throw so the
+     * worker can move the job to its dead-letter / retry path instead
+     * of silently no-op'ing.
+     *
+     * @return void
+     */
+    public function testMissingIdThrows(): void
+    {
+        $task = new ImageVariantTask();
+
+        $this->expectException(QueueException::class);
+        $this->expectExceptionMessage('id');
+        $task->run([], 1);
+    }
+
+    /**
+     * Missing `operations` is also a misconfigured payload — same reason.
+     *
+     * @return void
+     */
+    public function testMissingOperationsThrows(): void
+    {
+        $task = new ImageVariantTask();
+
+        $this->expectException(QueueException::class);
+        $this->expectExceptionMessage('operations');
+        $task->run(['id' => 1], 1);
+    }
+
+    /**
+     * A job for an entity that no longer exists must soft-fail (no exception,
+     * no log spam). This matches the regeneration use case: an admin queues
+     * a batch, deletes a file mid-flight, and the corresponding job arrives
+     * to find nothing. That's expected, not an error.
+     *
+     * @return void
+     */
+    public function testMissingEntityIsNoOp(): void
+    {
+        $task = new ImageVariantTask();
+
+        $task->run([
+            'id' => 999999,
+            'operations' => ['thumbnail' => ['width' => 50]],
+        ], 1);
+
+        // No exception, no assertion needed beyond reaching this point.
+        $this->assertTrue(true);
+    }
+}

--- a/tests/TestCase/Queue/Task/ImageVariantTaskTest.php
+++ b/tests/TestCase/Queue/Task/ImageVariantTaskTest.php
@@ -36,13 +36,18 @@ class ImageVariantTaskTest extends FileStorageTestCase
         // Conjure a minimal `queued_jobs` table so the Task base class's
         // LocatorAwareTrait lookup succeeds. A full Queue plugin migration
         // isn't needed here — the assertions only exercise validation +
-        // missing-entity branches and never persist a job.
+        // missing-entity branches and never persist a job. Keep the schema
+        // portable across SQLite/MySQL/Postgres (no AUTOINCREMENT keyword);
+        // SQLite uses AUTOINCREMENT, MySQL needs AUTO_INCREMENT, and
+        // Postgres uses SERIAL — a plain PRIMARY KEY without auto-increment
+        // works on all three since we never insert rows here.
         $connection = ConnectionManager::get('test');
         $connection->execute(
             'CREATE TABLE IF NOT EXISTS queued_jobs ('
-            . '  id INTEGER PRIMARY KEY AUTOINCREMENT,'
+            . '  id INTEGER NOT NULL,'
             . '  job_task VARCHAR(255),'
-            . '  data TEXT'
+            . '  data TEXT,'
+            . '  PRIMARY KEY (id)'
             . ')',
         );
     }

--- a/tests/TestCase/Queue/Task/ImageVariantTaskTest.php
+++ b/tests/TestCase/Queue/Task/ImageVariantTaskTest.php
@@ -12,16 +12,16 @@ use Queue\Model\QueueException;
  */
 class ImageVariantTaskTest extends FileStorageTestCase
 {
- /**
-  * Only the FileStorage fixture is loaded. The Queue plugin's
-  * `queued_jobs` table is not part of this test app's schema, but the
-  * Task base class fetches it eagerly via LocatorAwareTrait — we side-
-  * step by creating the table manually as a one-off in setUp(). This
-  * lets the failure-path tests below (validation + soft no-op) work
-  * without dragging in the full Queue plugin migrations setup.
-  *
-  * @var array<string>
-  */
+    /**
+     * Only the FileStorage fixture is loaded. The Queue plugin's
+     * `queued_jobs` table is not part of this test app's schema, but the
+     * Task base class fetches it eagerly via LocatorAwareTrait — we side-
+     * step by creating the table manually as a one-off in setUp(). This
+     * lets the failure-path tests below (validation + soft no-op) work
+     * without dragging in the full Queue plugin migrations setup.
+     *
+     * @var array<string>
+     */
     protected array $fixtures = [
         'plugin.FileStorage.FileStorage',
     ];


### PR DESCRIPTION
## Summary

Second of three strategic items from the audit. The `ImageVariantGenerateCommand` runs inline and blocks the calling shell for the whole batch — fine for one-off CLI use, but unusable from an admin UI button on a deployment with thousands of attachments. This adds a Queue-plugin task so per-entity variant regeneration can be dispatched in the background.

## What's in

- **`FileStorage\Queue\Task\ImageVariantTask`** — per-entity Queue plugin task. Implements the same processor pipeline as the inline command path (`entityToFileObject` → `withVariants` → `processor->process` → `save`) but runs one entity per dispatched job.
  - Soft-fails when the entity has been deleted between enqueue and dispatch (no exception, no log noise — a regeneration job for a since-deleted file is expected, not an error).
  - Throws `QueueException` on misconfigured payloads (missing `id` or `operations`) so the worker can apply retry / dead-letter behavior.
  - Same recursion-guard pattern as the existing inline path: strips the FileStorage behavior for the metadata save inside `processEntity()` so the afterSave processor pipeline doesn't re-fire on the queued save. Wrapped in `try/finally` so a save throw doesn't leave the table permanently missing the behavior.

- **`ImageVariantGenerateCommand --queue` option** — when set, enqueues one `ImageVariantTask` job per entity instead of processing inline. Aborts with a clear message if cakephp-queue isn't installed (the package is in `suggest`, not `require`, so consumers that don't want a queue dependency aren't forced into one).

## Job data shape

```php
[
    'id'           => 'fs-entity-uuid-or-id',  // REQUIRED — FileStorage row id
    'operations'   => [                         // REQUIRED — same shape as `imageVariants` config
        'thumbnail' => ['width' => 100],
        'medium'    => ['width' => 600],
    ],
    'adapter'      => 'Local',                  // optional
    'merge'        => true,                     // optional (default true): keep existing variants
    'storageTable' => 'FileStorage.FileStorage', // optional
]
```

## Use cases

- Admin "regenerate variants" button enqueues per-entity jobs and returns immediately
- CI-triggered backfill of a new variant size across an existing image set
- Spread renderer CPU cost across multiple workers naturally

## Tests

Three new tests in `ImageVariantTaskTest`:

- `testMissingIdThrows` — payload validation
- `testMissingOperationsThrows` — payload validation
- `testMissingEntityIsNoOp` — soft-fail when entity has been deleted between enqueue and dispatch

The test setUp creates a minimal `queued_jobs` table on the test SQLite connection so the Task base class's LocatorAwareTrait lookup succeeds without dragging the full Queue plugin migration setup into this plugin's test app. The full happy path is covered by the existing inline command tests plus integration in any app that wires both plugins together.

phpunit (97/97), phpstan, and phpcs all clean.
