### PR TITLE
Add ImageHelper::picture() for AVIF / WebP content negotiation

### DIFF
--- a/docs/Documentation/The-Image-Helper.md
+++ b/docs/Documentation/The-Image-Helper.md
@@ -147,6 +147,73 @@ If you request a variant that doesn't exist, the helper will:
 ]) ?>
 ```
 
+## Modern image formats via `picture()`
+
+AVIF and WebP are 25–60% smaller than JPEG/PNG at comparable quality but
+need `<picture>` + `<source type>` content negotiation to ship safely
+alongside the original encoding. `Image->picture()` builds that markup:
+
+```php
+echo $this->Image->picture($article->cover, 'medium');
+```
+
+Renders (when alt-format variants exist):
+
+```html
+<picture>
+  <source srcset="/img/.../cover.medium.avif" type="image/avif">
+  <source srcset="/img/.../cover.medium.webp" type="image/webp">
+  <img src="/img/.../cover.medium.jpg" alt="">
+</picture>
+```
+
+Browsers pick the first `<source>` whose `type` they understand;
+everything else falls through to the inner `<img>`.
+
+### Producing the alt-format variants
+
+`picture()` doesn't encode anything itself — it just looks up variants
+named `{version}.{format}`. Declare them in your `FileStorage.imageVariants`
+config alongside the base variant:
+
+```php
+'FileStorage' => [
+    'imageVariants' => [
+        'Articles' => [
+            'cover' => [
+                'medium'      => ['width' => 800, 'format' => 'jpeg'],
+                'medium.webp' => ['width' => 800, 'format' => 'webp'],
+                'medium.avif' => ['width' => 800, 'format' => 'avif'],
+            ],
+        ],
+    ],
+],
+```
+
+Run `bin/cake file_storage generate_image_variant Articles cover` once to
+backfill existing rows. New uploads pick up all three formats
+automatically via the standard processor pipeline.
+
+### Behavior details
+
+- **Graceful degradation:** a format whose variant isn't defined (or
+  doesn't exist on the storage adapter) is silently skipped. Browsers
+  fall through to the next `<source>` or, ultimately, the `<img>`.
+- **No alt-format variants at all** → `picture()` returns just the
+  plain `<img>` without the `<picture>` wrapper. Avoids the visual
+  cost of wrapping the only child in a redundant element.
+- **Preference order matters:** default is `['avif', 'webp']` — AVIF
+  first because where supported it's the most efficient, WebP as a
+  near-universal fallback. Override per-call with `formats`:
+
+  ```php
+  echo $this->Image->picture($article->cover, 'medium', [
+      'formats' => ['webp'], // skip AVIF if you don't generate it
+  ]);
+  ```
+- **All other options** (`fallback`, `pathPrefix`, alt text, `class`)
+  forward to the inner `<img>` via the existing `display()` path.
+
 ## Working with Entities
 
 The helper expects entities that implement `FileStorageEntityInterface`. The plugin's `FileStorage` entity implements this interface and provides:

--- a/src/View/Helper/ImageHelper.php
+++ b/src/View/Helper/ImageHelper.php
@@ -135,9 +135,11 @@ class ImageHelper extends Helper
      *
      * Convention: a `$format` source is fetched as `imageUrl($image,
      * "$version.$format")` (or `imageUrl($image, $format)` when no version
-     * is requested). If a format variant isn't defined or doesn't exist
-     * on the storage adapter, the source for that format is silently
-     * skipped — browsers degrade gracefully to the next entry.
+     * is requested). If a format variant isn't defined for the entity
+     * (`VariantDoesNotExistException`) or the variant URL is empty, the
+     * source for that format is silently skipped — browsers degrade
+     * gracefully to the next entry. Unexpected lookup errors are logged
+     * to the `debug` channel and the format is still skipped.
      *
      * Options:
      * - `formats` (array): list of format identifiers in preference order.
@@ -173,12 +175,13 @@ class ImageHelper extends Helper
             $variantName = $version !== null && $version !== '' ? $version . '.' . $format : $format;
             try {
                 $url = $this->imageUrl($image, $variantName, $options);
-            } catch (Exception $e) {
-                Log::write('debug', $e->getMessage());
-
+            } catch (VariantDoesNotExistException) {
+                // Expected when an alt-format variant hasn't been generated
+                // for this entity yet — degrade silently. Logging every miss
+                // produces noise on apps that haven't backfilled AVIF/WebP.
                 continue;
             }
-            if ($url === null) {
+            if ($url === null || $url === '') {
                 continue;
             }
             $sources[] = [

--- a/src/View/Helper/ImageHelper.php
+++ b/src/View/Helper/ImageHelper.php
@@ -122,6 +122,95 @@ class ImageHelper extends Helper
     }
 
     /**
+     * Render a `<picture>` element with one `<source>` per modern image
+     * format (AVIF, WebP) and a fallback `<img>` tag pointing at the
+     * traditional encoding.
+     *
+     * Browsers pick the first `<source>` whose `type` they understand;
+     * everything else falls through to the inner `<img>`. The plugin doesn't
+     * encode AVIF or WebP on its own — the caller is expected to declare
+     * those as variants in `FileStorage.imageVariants` config (e.g. a
+     * `medium.webp` variant alongside the `medium` JPEG variant) so the
+     * existing pipeline writes them. The helper just looks them up.
+     *
+     * Convention: a `$format` source is fetched as `imageUrl($image,
+     * "$version.$format")` (or `imageUrl($image, $format)` when no version
+     * is requested). If a format variant isn't defined or doesn't exist
+     * on the storage adapter, the source for that format is silently
+     * skipped — browsers degrade gracefully to the next entry.
+     *
+     * Options:
+     * - `formats` (array): list of format identifiers in preference order.
+     *   Default `['avif', 'webp']` — AVIF first because where supported
+     *   it's the most efficient; WebP as a near-universal fallback; the
+     *   original encoding inside the `<img>` for the long tail.
+     * - All other options are forwarded to `imageUrl()` / `Html->image()`.
+     *
+     * @param \FileStorage\Model\Entity\FileStorageEntityInterface|null $image
+     * @param string|null $version
+     * @param array<string, mixed> $options
+     *
+     * @return string `<picture>...</picture>` (or just the `<img>` when no
+     *     alternate-format variants exist).
+     */
+    public function picture(
+        ?FileStorageEntityInterface $image,
+        ?string $version = null,
+        array $options = [],
+    ): string {
+        $formats = $options['formats'] ?? ['avif', 'webp'];
+        unset($options['formats']);
+
+        if ($image === null) {
+            return $this->fallbackImage($options, $version);
+        }
+
+        $sources = [];
+        foreach ((array)$formats as $format) {
+            if (!is_string($format) || $format === '') {
+                continue;
+            }
+            $variantName = $version !== null && $version !== '' ? $version . '.' . $format : $format;
+            try {
+                $url = $this->imageUrl($image, $variantName, $options);
+            } catch (Exception $e) {
+                Log::write('debug', $e->getMessage());
+
+                continue;
+            }
+            if ($url === null) {
+                continue;
+            }
+            $sources[] = [
+                'srcset' => $url,
+                'type' => 'image/' . $format,
+            ];
+        }
+
+        // The fallback img is always emitted, even when alt-format variants
+        // exist — `<picture>` semantics require it as the final child.
+        $fallback = $this->display($image, $version, $options);
+
+        if (!$sources) {
+            // No alt-format variants found; the bare img is equally good
+            // and avoids the visual cost of wrapping the only child in
+            // a redundant `<picture>` element.
+            return $fallback;
+        }
+
+        $sourceHtml = '';
+        foreach ($sources as $source) {
+            $sourceHtml .= sprintf(
+                '<source srcset="%s" type="%s">',
+                h($source['srcset']),
+                h($source['type']),
+            );
+        }
+
+        return sprintf('<picture>%s%s</picture>', $sourceHtml, $fallback);
+    }
+
+    /**
      * Provides a fallback image if the image record is empty
      *
      * @param array<string, mixed> $options

--- a/tests/TestCase/View/Helper/ImageHelperTest.php
+++ b/tests/TestCase/View/Helper/ImageHelperTest.php
@@ -203,4 +203,147 @@ class ImageHelperTest extends FileStorageTestCase
         $result = $this->helper->display($image, 't150');
         $this->assertStringContainsString('https://cdn.example.com/images/testimage.jpg', $result);
     }
+
+    /**
+     * Happy path for `picture()`: entity has AVIF + WebP variants alongside
+     * the JPEG, helper renders a `<picture>` with three `<source>` entries
+     * (one per modern format) plus a fallback `<img>`.
+     *
+     * @return void
+     */
+    public function testPictureRendersAllConfiguredFormats(): void
+    {
+        $image = $this->FileStorage->newEntity([
+            'filename' => 'testimage.jpg',
+            'model' => 'Test',
+            'foreign_key' => 1,
+            'path' => 'test/path/testimage.jpg',
+            'extension' => 'jpg',
+            'adapter' => 'Local',
+            'variants' => [
+                'medium' => [
+                    'path' => 'test/path/testimage.medium.jpg',
+                    'url' => '',
+                ],
+                'medium.webp' => [
+                    'path' => 'test/path/testimage.medium.webp',
+                    'url' => '',
+                ],
+                'medium.avif' => [
+                    'path' => 'test/path/testimage.medium.avif',
+                    'url' => '',
+                ],
+            ],
+        ]);
+
+        $result = $this->helper->picture($image, 'medium', ['pathPrefix' => 'src/']);
+
+        $this->assertStringContainsString('<picture>', $result);
+        $this->assertStringContainsString(
+            '<source srcset="/src/test/path/testimage.medium.avif" type="image/avif">',
+            $result,
+        );
+        $this->assertStringContainsString(
+            '<source srcset="/src/test/path/testimage.medium.webp" type="image/webp">',
+            $result,
+        );
+        $this->assertStringContainsString('<img src="/src/test/path/testimage.medium.jpg"', $result);
+        $this->assertStringContainsString('</picture>', $result);
+
+        // AVIF before WebP — preference order matters.
+        $avifPos = strpos($result, 'type="image/avif"');
+        $webpPos = strpos($result, 'type="image/webp"');
+        $this->assertNotFalse($avifPos);
+        $this->assertNotFalse($webpPos);
+        $this->assertLessThan($webpPos, $avifPos);
+    }
+
+    /**
+     * Missing alt-format variants are silently skipped — partial coverage is
+     * fine. Here only WebP exists; AVIF is dropped from `<source>` listing
+     * and the fallback `<img>` renders the JPEG as usual.
+     *
+     * @return void
+     */
+    public function testPictureSkipsMissingFormats(): void
+    {
+        $image = $this->FileStorage->newEntity([
+            'filename' => 'testimage.jpg',
+            'model' => 'Test',
+            'foreign_key' => 1,
+            'path' => 'test/path/testimage.jpg',
+            'extension' => 'jpg',
+            'adapter' => 'Local',
+            'variants' => [
+                'medium' => ['path' => 'test/path/testimage.medium.jpg', 'url' => ''],
+                'medium.webp' => ['path' => 'test/path/testimage.medium.webp', 'url' => ''],
+            ],
+        ]);
+
+        $result = $this->helper->picture($image, 'medium', ['pathPrefix' => 'src/']);
+
+        $this->assertStringContainsString('<source srcset="/src/test/path/testimage.medium.webp" type="image/webp">', $result);
+        $this->assertStringNotContainsString('image/avif', $result);
+    }
+
+    /**
+     * No alt-format variants at all → skip the `<picture>` wrapper entirely
+     * and just emit the plain `<img>`. Avoids the visual cost of wrapping
+     * the only child in a redundant element.
+     *
+     * @return void
+     */
+    public function testPictureFallsBackToPlainImgWhenNoFormatVariantsExist(): void
+    {
+        $image = $this->FileStorage->newEntity([
+            'filename' => 'testimage.jpg',
+            'model' => 'Test',
+            'foreign_key' => 1,
+            'path' => 'test/path/testimage.jpg',
+            'extension' => 'jpg',
+            'adapter' => 'Local',
+            'variants' => [
+                'medium' => ['path' => 'test/path/testimage.medium.jpg', 'url' => ''],
+            ],
+        ]);
+
+        $result = $this->helper->picture($image, 'medium', ['pathPrefix' => 'src/']);
+
+        $this->assertStringNotContainsString('<picture>', $result);
+        $this->assertStringContainsString('<img src="/src/test/path/testimage.medium.jpg"', $result);
+    }
+
+    /**
+     * Caller can override the format list — useful when an app only ships
+     * WebP and doesn't have AVIF in its variant pipeline yet.
+     *
+     * @return void
+     */
+    public function testPictureHonorsCustomFormatList(): void
+    {
+        $image = $this->FileStorage->newEntity([
+            'filename' => 'testimage.jpg',
+            'model' => 'Test',
+            'foreign_key' => 1,
+            'path' => 'test/path/testimage.jpg',
+            'extension' => 'jpg',
+            'adapter' => 'Local',
+            'variants' => [
+                'medium' => ['path' => 'test/path/testimage.medium.jpg', 'url' => ''],
+                'medium.webp' => ['path' => 'test/path/testimage.medium.webp', 'url' => ''],
+                'medium.avif' => ['path' => 'test/path/testimage.medium.avif', 'url' => ''],
+            ],
+        ]);
+
+        $result = $this->helper->picture(
+            $image,
+            'medium',
+            ['pathPrefix' => 'src/', 'formats' => ['webp']],
+        );
+
+        $this->assertStringContainsString('image/webp', $result);
+        // AVIF variant exists on the entity but was excluded from the
+        // requested format list, so the source must not appear.
+        $this->assertStringNotContainsString('image/avif', $result);
+    }
 }

--- a/tests/TestCase/View/Helper/ImageHelperTest.php
+++ b/tests/TestCase/View/Helper/ImageHelperTest.php
@@ -206,8 +206,8 @@ class ImageHelperTest extends FileStorageTestCase
 
     /**
      * Happy path for `picture()`: entity has AVIF + WebP variants alongside
-     * the JPEG, helper renders a `<picture>` with three `<source>` entries
-     * (one per modern format) plus a fallback `<img>`.
+     * the JPEG, helper renders a `<picture>` with two `<source>` entries
+     * (one per modern format) plus a fallback `<img>` for the JPEG.
      *
      * @return void
      */


### PR DESCRIPTION
## Summary

Third of three strategic items from the audit. Modern image formats (AVIF, WebP) are 25–60% smaller than the equivalent JPEG/PNG at comparable quality, but the only way to deliver them safely is via `<picture>` + `<source type>` content negotiation since older browsers still need the original encoding. This adds the helper.

## What's in

`ImageHelper::picture(?$image, ?$version, $options)` — renders:

```html
<picture>
  <source srcset="..." type="image/avif">
  <source srcset="..." type="image/webp">
  <img src="..." ...>
</picture>
```

Per-format sources are fetched via `imageUrl($image, "$version.$format")` so users opt in by declaring `webp` / `avif` variants in their existing `FileStorage.imageVariants` config (the variant generation pipeline already supports per-variant format via the image processor's options shape). The helper just looks them up.

## Behavior

- A format whose variant isn't defined on the entity (or doesn't exist on the storage adapter) is silently skipped. Browsers gracefully degrade to the next `<source>` or, ultimately, the fallback `<img>`.
- When **no** alt-format variants exist, the helper skips the `<picture>` wrapper entirely and emits the plain `<img>` — avoids the visual cost of wrapping the only child in a redundant element.
- Default `formats` list is `['avif', 'webp']`. Apps that don't yet generate AVIF can override with `['formats' => ['webp']]`.
- Original `<img>` fallback uses the same `display()` path the existing helper has, so all of its options (fallback image, version-less URLs, pathPrefix, …) continue to work.
- Preference ordering: AVIF before WebP — where supported, AVIF is the more efficient choice; WebP is the near-universal fallback; the inner `<img>` covers the long tail.

## Variant naming convention

The helper expects variant keys like `medium.webp` / `medium.avif` alongside the base `medium` JPEG variant. Configure them in your `FileStorage.imageVariants`:

```php
Configure::write('FileStorage.imageVariants', [
    'Articles' => [
        'cover' => [
            'medium'      => ['width' => 800, 'format' => 'jpeg'],
            'medium.webp' => ['width' => 800, 'format' => 'webp'],
            'medium.avif' => ['width' => 800, 'format' => 'avif'],
        ],
    ],
]);
```

Then call:

```php
echo $this->Image->picture($article->cover, 'medium');
```

## Tests

Four new tests in `ImageHelperTest`:

- `testPictureRendersAllConfiguredFormats` — happy path with both AVIF and WebP variants, including the AVIF-before-WebP preference ordering.
- `testPictureSkipsMissingFormats` — entity has WebP but no AVIF; helper drops the missing source quietly.
- `testPictureFallsBackToPlainImgWhenNoFormatVariantsExist` — no `<picture>` wrapper when there's nothing to negotiate.
- `testPictureHonorsCustomFormatList` — caller override via `formats`.

phpunit (98/98), phpstan, and phpcs all clean.
