### PR TITLE
Adopt TEntity table template + tighten Table method annotations

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The **FileStorage** plugin is giving you the possibility to upload and store fil
 
 Storage adapters are a unified interface that allow you to store file data to your local file system, in memory, in a database or into a zip file and remote systems. There is a database table keeping track of what you stored where. You can always write your own adapter or extend and overload existing ones.
 
-This branch is for use with **CakePHP 5.1+**. See [version map](https://github.com/dereuromark/cakephp-file-storage/wiki#cakephp-version-map) for details.
+This branch is for use with **CakePHP 5.3.4+**. See [version map](https://github.com/dereuromark/cakephp-file-storage/wiki#cakephp-version-map) for details.
 
 ## How it works
 

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
     "require": {
         "php": ">=8.2",
         "brick/varexporter": "^0.5.0 || ^0.6.0 || ^0.7.0",
-        "cakephp/cakephp": "^5.1.1",
+        "cakephp/cakephp": "^5.3.4",
         "php-collective/file-storage": "^1.0.0"
     },
     "require-dev": {

--- a/src/Model/Table/FileStorageTable.php
+++ b/src/Model/Table/FileStorageTable.php
@@ -27,17 +27,21 @@ use Cake\ORM\Table;
  * @method \FileStorage\Model\Entity\FileStorage newEntity(array $data, array $options = [])
  * @method array<\FileStorage\Model\Entity\FileStorage> newEntities(array $data, array $options = [])
  * @method \FileStorage\Model\Entity\FileStorage get(mixed $primaryKey, array|string $finder = 'all', \Psr\SimpleCache\CacheInterface|string|null $cache = null, \Closure|string|null $cacheKey = null, mixed ...$args)
- * @method \FileStorage\Model\Entity\FileStorage findOrCreate($search, ?callable $callback = null, array $options = [])
- * @method \FileStorage\Model\Entity\FileStorage patchEntity(\Cake\Datasource\EntityInterface $entity, array $data, array $options = [])
- * @method array<\FileStorage\Model\Entity\FileStorage> patchEntities(iterable $entities, array $data, array $options = [])
- * @method \FileStorage\Model\Entity\FileStorage|false save(\Cake\Datasource\EntityInterface $entity, array $options = [])
- * @method \FileStorage\Model\Entity\FileStorage saveOrFail(\Cake\Datasource\EntityInterface $entity, array $options = [])
- * @method \Cake\Datasource\ResultSetInterface<\FileStorage\Model\Entity\FileStorage>|false saveMany(iterable $entities, array $options = [])
- * @method \Cake\Datasource\ResultSetInterface<\FileStorage\Model\Entity\FileStorage> saveManyOrFail(iterable $entities, array $options = [])
- * @method \Cake\Datasource\ResultSetInterface<\FileStorage\Model\Entity\FileStorage>|false deleteMany(iterable $entities, array $options = [])
- * @method \Cake\Datasource\ResultSetInterface<\FileStorage\Model\Entity\FileStorage> deleteManyOrFail(iterable $entities, array $options = [])
+ * @method \FileStorage\Model\Entity\FileStorage findOrCreate(\Cake\ORM\Query\SelectQuery|callable|array $search, ?callable $callback = null, array $options = [])
+ * @method \FileStorage\Model\Entity\FileStorage patchEntity(\FileStorage\Model\Entity\FileStorage $entity, array $data, array $options = [])
+ * @method array<\FileStorage\Model\Entity\FileStorage> patchEntities(iterable<\FileStorage\Model\Entity\FileStorage> $entities, array $data, array $options = [])
+ * @method \FileStorage\Model\Entity\FileStorage|false save(\FileStorage\Model\Entity\FileStorage $entity, array $options = [])
+ * @method \FileStorage\Model\Entity\FileStorage saveOrFail(\FileStorage\Model\Entity\FileStorage $entity, array $options = [])
+ * @method \Cake\Datasource\ResultSetInterface<\FileStorage\Model\Entity\FileStorage>|false saveMany(iterable<\FileStorage\Model\Entity\FileStorage> $entities, array $options = [])
+ * @method \Cake\Datasource\ResultSetInterface<\FileStorage\Model\Entity\FileStorage> saveManyOrFail(iterable<\FileStorage\Model\Entity\FileStorage> $entities, array $options = [])
+ * @method \Cake\Datasource\ResultSetInterface<\FileStorage\Model\Entity\FileStorage>|false deleteMany(iterable<\FileStorage\Model\Entity\FileStorage> $entities, array $options = [])
+ * @method \Cake\Datasource\ResultSetInterface<\FileStorage\Model\Entity\FileStorage> deleteManyOrFail(iterable<\FileStorage\Model\Entity\FileStorage> $entities, array $options = [])
  * @mixin \Cake\ORM\Behavior\TimestampBehavior
  * @mixin \FileStorage\Model\Behavior\FileStorageBehavior
+ * @extends \Cake\ORM\Table<array{FileStorage: \FileStorage\Model\Behavior\FileStorageBehavior, Timestamp: \Cake\ORM\Behavior\TimestampBehavior}, \FileStorage\Model\Entity\FileStorage>
+ * @method bool delete(\FileStorage\Model\Entity\FileStorage $entity, array $options = [])
+ * @method bool deleteOrFail(\FileStorage\Model\Entity\FileStorage $entity, array $options = [])
+ * @method \FileStorage\Model\Entity\FileStorage|array<\FileStorage\Model\Entity\FileStorage> loadInto(\FileStorage\Model\Entity\FileStorage|array<\FileStorage\Model\Entity\FileStorage> $entities, array $contain)
  */
 class FileStorageTable extends Table
 {

--- a/src/Model/Table/FileStorageTable.php
+++ b/src/Model/Table/FileStorageTable.php
@@ -22,7 +22,7 @@ use Cake\ORM\Table;
  * @author Florian Krämer
  * @copyright 2012 - 2020 Florian Krämer
  * @license MIT
- *
+ * @extends \Cake\ORM\Table<array{FileStorage: \FileStorage\Model\Behavior\FileStorageBehavior, Timestamp: \Cake\ORM\Behavior\TimestampBehavior}, \FileStorage\Model\Entity\FileStorage>
  * @method \FileStorage\Model\Entity\FileStorage newEmptyEntity()
  * @method \FileStorage\Model\Entity\FileStorage newEntity(array $data, array $options = [])
  * @method array<\FileStorage\Model\Entity\FileStorage> newEntities(array $data, array $options = [])
@@ -36,12 +36,11 @@ use Cake\ORM\Table;
  * @method \Cake\Datasource\ResultSetInterface<\FileStorage\Model\Entity\FileStorage> saveManyOrFail(iterable<\FileStorage\Model\Entity\FileStorage> $entities, array $options = [])
  * @method \Cake\Datasource\ResultSetInterface<\FileStorage\Model\Entity\FileStorage>|false deleteMany(iterable<\FileStorage\Model\Entity\FileStorage> $entities, array $options = [])
  * @method \Cake\Datasource\ResultSetInterface<\FileStorage\Model\Entity\FileStorage> deleteManyOrFail(iterable<\FileStorage\Model\Entity\FileStorage> $entities, array $options = [])
- * @mixin \Cake\ORM\Behavior\TimestampBehavior
- * @mixin \FileStorage\Model\Behavior\FileStorageBehavior
- * @extends \Cake\ORM\Table<array{FileStorage: \FileStorage\Model\Behavior\FileStorageBehavior, Timestamp: \Cake\ORM\Behavior\TimestampBehavior}, \FileStorage\Model\Entity\FileStorage>
  * @method bool delete(\FileStorage\Model\Entity\FileStorage $entity, array $options = [])
  * @method bool deleteOrFail(\FileStorage\Model\Entity\FileStorage $entity, array $options = [])
  * @method \FileStorage\Model\Entity\FileStorage|array<\FileStorage\Model\Entity\FileStorage> loadInto(\FileStorage\Model\Entity\FileStorage|array<\FileStorage\Model\Entity\FileStorage> $entities, array $contain)
+ * @mixin \Cake\ORM\Behavior\TimestampBehavior
+ * @mixin \FileStorage\Model\Behavior\FileStorageBehavior
  */
 class FileStorageTable extends Table
 {


### PR DESCRIPTION
## Summary

Re-runs the latest `dereuromark/cakephp-ide-helper` model annotator on `FileStorageTable`. Adds the second `TEntity` template parameter to the `@extends` declaration, and tightens `patchEntity` / `save` / `saveMany` / `loadInto` / `delete` method signatures from generic `EntityInterface` to the concrete `FileStorage` entity class.

This lets PHPStan flow the entity type end-to-end through `find()->first()` and `find()->toArray()` chains in downstream code, removing inline `@var` annotations consumer apps currently sprinkle on every callsite.

## Version floor

| Dependency | Before | After | Why |
|---|---|---|---|
| `cakephp/cakephp` | `^5.1.1` | `^5.3.4` | Introduces the second `TEntity` template on `Cake\ORM\Table` |

Older versions would surface a `generics.moreTypes` error from PHPStan (`Cake\ORM\Table supports only 1 template type`).

## Notes

The annotator also tried to add a `$sort` Entity property that was actually picked up from a consumer app's MySQL schema rather than the plugin's own migrations — scrubbed from this diff.

## Verification

- `composer stan` clean (PHPStan level 8)
- `composer cs-check` clean
