### PR TITLE
Enable clean docs URLs and update deploy actions to Node 24

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -23,19 +23,19 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 20
           cache: npm
           cache-dependency-path: docs/package-lock.json
 
       - name: Setup Pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@v6
 
       - name: Install dependencies
         run: npm ci
@@ -46,7 +46,7 @@ jobs:
         working-directory: docs
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: docs/.vitepress/dist
 
@@ -59,4 +59,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -44,6 +44,7 @@ export default defineConfig({
   description: 'Store and serve files in any backend for CakePHP — FlySystem adapters, image variants, signed URLs, and a self-contained admin backend.',
   base: '/cakephp-file-storage/',
   lastUpdated: true,
+  cleanUrls: true,
   sitemap: {
     hostname: 'https://dereuromark.github.io/cakephp-file-storage/',
   },


### PR DESCRIPTION
Follow-up to the docs site.

- **Clean URLs** — `cleanUrls: true`, so pages drop the `.html` suffix (e.g. `/serving/signed-urls`). GitHub Pages serves the underlying `.html` file, and this also makes the extensionless links in the README resolve.
- **Node 24 actions** — bump the `deploy-docs` workflow to the current action majors, all of which run on `node24`, ahead of GitHub removing the Node 20 runner (forced cutover June 2 2026):
  - `checkout` v4 → v6
  - `setup-node` v4 → v6
  - `configure-pages` v5 → v6
  - `upload-pages-artifact` v3 → v5
  - `deploy-pages` v4 → v5

The site builds cleanly (`npm run docs:build`).
