### PR TITLE
Default file_storage foreign_key and user_id to int following unsigned_primary_keys

### DIFF
--- a/config/Migrations/20141213004653_initial_migration.php
+++ b/config/Migrations/20141213004653_initial_migration.php
@@ -8,17 +8,21 @@ class InitialMigration extends BaseMigration {
  * Migrate Up.
  */
 	public function up() {
-		// user_id and foreign_key reference integer primary keys (the app's users
-		// and any host record), so they follow the application's primary-key
-		// signedness. The flag is false (signed) when unset, so an unset flag yields
-		// signed columns matching the default-signed ids they reference. The id stays
-		// a char(36) UUID (the storage library's file identity). Unsigned only on MySQL.
+		$type = (string)Configure::read('Polymorphic.type', 'integer');
 		$signed = !(bool)Configure::read('Migrations.unsigned_primary_keys', false);
+
+		$polymorphicOptions = [
+			'null' => true,
+			'default' => null,
+		];
+		if (in_array($type, ['integer', 'biginteger'], true)) {
+			$polymorphicOptions['signed'] = $signed;
+		}
 
 		$this->table('file_storage', ['id' => false, 'primary_key' => 'id'])
 			->addColumn('id', 'char', ['limit' => 36])
-			->addColumn('user_id', 'biginteger', ['null' => true, 'default' => null, 'signed' => $signed])
-			->addColumn('foreign_key', 'biginteger', ['null' => true, 'default' => null, 'signed' => $signed])
+			->addColumn('user_id', 'integer', ['null' => true, 'default' => null, 'signed' => $signed])
+			->addColumn('foreign_key', $type, $polymorphicOptions)
 			->addColumn('model', 'string', ['limit' => 128, 'null' => true, 'default' => null])
 			->addColumn('filename', 'string', ['limit' => 255, 'null' => true, 'default' => null])
 			->addColumn('filesize', 'integer', ['limit' => 16, 'null' => true, 'default' => null])

--- a/config/Migrations/20141213004653_initial_migration.php
+++ b/config/Migrations/20141213004653_initial_migration.php
@@ -1,4 +1,5 @@
 <?php
+use Cake\Core\Configure;
 use Migrations\BaseMigration;
 
 class InitialMigration extends BaseMigration {
@@ -7,10 +8,17 @@ class InitialMigration extends BaseMigration {
  * Migrate Up.
  */
 	public function up() {
+		// user_id and foreign_key reference integer primary keys (the app's users
+		// and any host record), so they follow the application's primary-key
+		// signedness. The flag is false (signed) when unset, so an unset flag yields
+		// signed columns matching the default-signed ids they reference. The id stays
+		// a char(36) UUID (the storage library's file identity). Unsigned only on MySQL.
+		$signed = !(bool)Configure::read('Migrations.unsigned_primary_keys', false);
+
 		$this->table('file_storage', ['id' => false, 'primary_key' => 'id'])
 			->addColumn('id', 'char', ['limit' => 36])
-			->addColumn('user_id', 'char', ['limit' => 36, 'null' => true, 'default' => null])
-			->addColumn('foreign_key', 'char', ['limit' => 36, 'null' => true, 'default' => null])
+			->addColumn('user_id', 'biginteger', ['null' => true, 'default' => null, 'signed' => $signed])
+			->addColumn('foreign_key', 'biginteger', ['null' => true, 'default' => null, 'signed' => $signed])
 			->addColumn('model', 'string', ['limit' => 128, 'null' => true, 'default' => null])
 			->addColumn('filename', 'string', ['limit' => 255, 'null' => true, 'default' => null])
 			->addColumn('filesize', 'integer', ['limit' => 16, 'null' => true, 'default' => null])

--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -39,45 +39,41 @@ your local `migrations migrate` instead.
 
 ### Foreign key column types
 
-::: warning Foreign keys default to UUID (CHAR(36)), not integers
-The shipped migration creates `file_storage` with a UUID primary key **and**
-UUID-shaped foreign-key columns:
+The shipped migration creates `file_storage` with **integer foreign keys** that
+follow your application's primary-key signedness (via the
+`Migrations.unsigned_primary_keys` flag — signed by default), while the `id`
+stays a `CHAR(36)` UUID:
 
 | Column | Default type | Purpose |
 |--------|--------------|---------|
 | `id` | `CHAR(36)` | The file row's own id (a UUID — keep as-is, see below). |
-| `foreign_key` | `CHAR(36)` | The owning record's id (your `Users.id`, `Posts.id`, …). |
-| `user_id` | `CHAR(36)` | Optional uploader / owner id. |
+| `foreign_key` | `BIGINTEGER` | The owning record's id (your `Users.id`, `Posts.id`, …). |
+| `user_id` | `BIGINTEGER` | Optional uploader / owner id. |
 
-If your app uses **integer / auto-increment primary keys** (the CakePHP
-default), `CHAR(36)` is the wrong type for `foreign_key` and `user_id`: an
-integer id like `42` is silently stored as the string `"42"`, the column is
-oversized, and you cannot add a real DB foreign-key constraint or join cleanly
-against your integer-keyed tables.
-:::
+This matches the common case where your records use integer / auto-increment
+primary keys (the CakePHP default), so `foreign_key` and `user_id` line up with
+your integer-keyed tables and the signedness matches their primary keys.
 
-**To use integer foreign keys**, copy the migration into your app and change
-those two columns (keep everything else, including `id`):
+#### Using UUID foreign keys
+
+If the records your files belong to use **UUID primary keys**, copy the migration
+into your app and change those two columns to `char` (keep everything else,
+including `id`):
 
 ```php
 $this->table('file_storage', ['id' => false, 'primary_key' => 'id'])
-    ->addColumn('id', 'char', ['limit' => 36])                          // keep: see note below
-    ->addColumn('user_id', 'integer', ['null' => true, 'default' => null])
-    ->addColumn('foreign_key', 'integer', ['null' => true, 'default' => null])
+    ->addColumn('id', 'char', ['limit' => 36])
+    ->addColumn('user_id', 'char', ['limit' => 36, 'null' => true, 'default' => null])
+    ->addColumn('foreign_key', 'char', ['limit' => 36, 'null' => true, 'default' => null])
     // … all remaining columns unchanged
     ->create();
 ```
-
-Use `biginteger` instead of `integer` if your tables use big-integer keys.
 
 ::: tip Why keep the id as CHAR(36)?
 The `file_storage.id` is the *file row's own* identifier, generated as a UUID by
 the plugin's storage / path layer (don't pre-fill it — let the table assign it).
 It is **not** a reference to one of your records. Only `foreign_key` / `user_id`
-point at *your* tables, so only those need to match your app's key type.
-
-A future major version may flip this default to integer foreign keys (UUID
-becoming opt-in) — see [issue #37](https://github.com/dereuromark/cakephp-file-storage/issues/37).
+point at *your* tables, so only those default to integer to match the typical app.
 :::
 
 ## Adapter-specific configuration

--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -64,11 +64,16 @@ config key (default `'integer'`). Accepted values:
 | `'uuid'` | `CHAR(36)` | No signed option (not applicable) |
 | `'binaryuuid'` | `BINARY(16)` | No signed option (not applicable) |
 
-To use UUID foreign keys, set the config before running migrations:
+To use UUID foreign keys, add the config key before running migrations on a *fresh
+install*. Existing installs require a separate app-side migration to alter the
+`foreign_key` column — changing this value after the initial migration has no
+effect on an already-created column.
 
 ```php
-// config/app.php or config/app_local.php
-Configure::write('Polymorphic.type', 'uuid'); // or 'binaryuuid'
+// config/app.php (merged into Configure at bootstrap, including the migrations CLI)
+'Polymorphic' => [
+    'type' => 'uuid', // integer (default) | biginteger | uuid | binaryuuid
+],
 ```
 
 ::: tip Why keep the id as CHAR(36)?

--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -39,41 +39,44 @@ your local `migrations migrate` instead.
 
 ### Foreign key column types
 
-The shipped migration creates `file_storage` with **integer foreign keys** that
-follow your application's primary-key signedness (via the
-`Migrations.unsigned_primary_keys` flag — signed by default), while the `id`
-stays a `CHAR(36)` UUID:
+The shipped migration creates `file_storage` with the following column types:
 
 | Column | Default type | Purpose |
 |--------|--------------|---------|
-| `id` | `CHAR(36)` | The file row's own id (a UUID — keep as-is, see below). |
-| `foreign_key` | `BIGINTEGER` | The owning record's id (your `Users.id`, `Posts.id`, …). |
-| `user_id` | `BIGINTEGER` | Optional uploader / owner id. |
+| `id` | `CHAR(36)` | The file row's own id (a UUID — always stays CHAR(36)). |
+| `foreign_key` | `integer` | The owning record's id (your `Users.id`, `Posts.id`, …). Configurable via `Polymorphic.type`. |
+| `user_id` | `integer` | Optional uploader / owner id — a plain integer FK to the app's users table. |
 
-This matches the common case where your records use integer / auto-increment
-primary keys (the CakePHP default), so `foreign_key` and `user_id` line up with
-your integer-keyed tables and the signedness matches their primary keys.
+`user_id` and `foreign_key` both follow your application's primary-key signedness
+(via the `Migrations.unsigned_primary_keys` flag — signed by default) for integer
+variants. The `id` always stays a `CHAR(36)` UUID (the storage library's file
+identity).
 
-#### Using UUID foreign keys
+#### Configuring the foreign_key type
 
-If the records your files belong to use **UUID primary keys**, copy the migration
-into your app and change those two columns to `char` (keep everything else,
-including `id`):
+The `foreign_key` column type is controlled by the global `Polymorphic.type`
+config key (default `'integer'`). Accepted values:
+
+| Value | Column type | Signedness |
+|-------|-------------|------------|
+| `'integer'` (default) | `INTEGER` | Follows `Migrations.unsigned_primary_keys` |
+| `'biginteger'` | `BIGINT` | Follows `Migrations.unsigned_primary_keys` |
+| `'uuid'` | `CHAR(36)` | No signed option (not applicable) |
+| `'binaryuuid'` | `BINARY(16)` | No signed option (not applicable) |
+
+To use UUID foreign keys, set the config before running migrations:
 
 ```php
-$this->table('file_storage', ['id' => false, 'primary_key' => 'id'])
-    ->addColumn('id', 'char', ['limit' => 36])
-    ->addColumn('user_id', 'char', ['limit' => 36, 'null' => true, 'default' => null])
-    ->addColumn('foreign_key', 'char', ['limit' => 36, 'null' => true, 'default' => null])
-    // … all remaining columns unchanged
-    ->create();
+// config/app.php or config/app_local.php
+Configure::write('Polymorphic.type', 'uuid'); // or 'binaryuuid'
 ```
 
 ::: tip Why keep the id as CHAR(36)?
 The `file_storage.id` is the *file row's own* identifier, generated as a UUID by
 the plugin's storage / path layer (don't pre-fill it — let the table assign it).
-It is **not** a reference to one of your records. Only `foreign_key` / `user_id`
-point at *your* tables, so only those default to integer to match the typical app.
+It is **not** a reference to one of your records. Only `foreign_key` points at
+*your* polymorphic host records; `user_id` is a concrete integer FK to the users
+table.
 :::
 
 ## Adapter-specific configuration

--- a/docs/guide/usage.md
+++ b/docs/guide/usage.md
@@ -13,7 +13,7 @@ your application. Each record contains:
 | Field | Description |
 |-------|-------------|
 | `id` | Unique UUID for the file. |
-| `foreign_key` | The id of the entity this file belongs to (e.g. user id, post id). A `BIGINTEGER` by default — see [Foreign key column types](./installation#foreign-key-column-types) to use UUID ids. |
+| `foreign_key` | The id of the entity this file belongs to (e.g. user id, post id). Type follows the global `Polymorphic.type` config (default `integer`) — see [Foreign key column types](./installation#foreign-key-column-types). |
 | `model` | The model name (e.g. `Users`, `Posts`). |
 | `collection` | The collection / type of file (e.g. `Avatar`, `Cover`, `Gallery`). |
 | `filename` | Original filename. |

--- a/docs/guide/usage.md
+++ b/docs/guide/usage.md
@@ -13,7 +13,7 @@ your application. Each record contains:
 | Field | Description |
 |-------|-------------|
 | `id` | Unique UUID for the file. |
-| `foreign_key` | The id of the entity this file belongs to (e.g. user id, post id). Stored as `CHAR(36)` by default — see [Foreign key column types](./installation#foreign-key-column-types) to use integer ids. |
+| `foreign_key` | The id of the entity this file belongs to (e.g. user id, post id). A `BIGINTEGER` by default — see [Foreign key column types](./installation#foreign-key-column-types) to use UUID ids. |
 | `model` | The model name (e.g. `Users`, `Posts`). |
 | `collection` | The collection / type of file (e.g. `Avatar`, `Cover`, `Gallery`). |
 | `filename` | Original filename. |


### PR DESCRIPTION
## Problem

`file_storage.foreign_key` (the owning record's id) is a polymorphic reference, and `user_id` references the app's users table. They were created as `CHAR(36)` UUIDs, which mismatches the common case where host records and users use integer / auto-increment primary keys.

## Fix

`foreign_key` now follows the global `Polymorphic.type` config (default `integer`), and `user_id` is a plain `integer` FK following `Migrations.unsigned_primary_keys`:

```php
// config/app.php or config/app_local.php
Configure::write('Polymorphic.type', 'uuid'); // integer (default) | biginteger | uuid | binaryuuid
```

- `id` stays `CHAR(36)` — it is the file row's own identity (generated by the storage / path layer), not a reference to your records.
- For the integer variants, signedness follows `Migrations.unsigned_primary_keys`; `uuid` / `binaryuuid` set no signedness.
- Docs updated (installation + usage): UUID foreign keys are now a one-line config switch instead of copying the migration.

Editing the create migration sets the default for fresh installs; existing installs are unaffected (the create migration does not re-run). Type/signedness only take effect on MySQL for the integer variants.
