### PR TITLE
Document file storage key types

### DIFF
--- a/src/Model/Entity/FileStorage.php
+++ b/src/Model/Entity/FileStorage.php
@@ -14,9 +14,9 @@ use Cake\ORM\Entity;
  *
  * @property array $variants
  * @property array $metadata
- * @property int $id
- * @property int|null $user_id
- * @property int|null $foreign_key
+ * @property string $id
+ * @property int|string|null $user_id
+ * @property int|string|null $foreign_key
  * @property string|null $model
  * @property string|null $filename
  * @property int|null $filesize

--- a/src/Model/Entity/FileStorage.php
+++ b/src/Model/Entity/FileStorage.php
@@ -15,7 +15,7 @@ use Cake\ORM\Entity;
  * @property array $variants
  * @property array $metadata
  * @property string $id
- * @property int|string|null $user_id
+ * @property int|null $user_id
  * @property int|string|null $foreign_key
  * @property string|null $model
  * @property string|null $filename


### PR DESCRIPTION
## Summary
- document the file-storage record id and polymorphic `foreign_key` with their real runtime types
- keep the non-polymorphic user-id docs integer-based

## Testing
- php -l src/Model/Entity/FileStorage.php