### PR TITLE
 Fix processImages() model alias.

### DIFF
--- a/src/Model/Behavior/FileStorageBehavior.php
+++ b/src/Model/Behavior/FileStorageBehavior.php
@@ -382,7 +382,7 @@ class FileStorageBehavior extends Behavior
         $imageSizes = (array)Configure::read('FileStorage.imageVariants');
 
         $collection = $entity->get('collection');
-        $model = $this->table()->getAlias();
+        $model = $entity->get('model');
 
         if (!isset($imageSizes[$model][$collection])) {
             return $file;


### PR DESCRIPTION
Fix: processImages uses table alias instead of entity model field for variant lookup

**Problem**
When following the [quick-start documentation](https://dereuromark.github.io/cakephp-file-storage/guide/quick-start) to set up a file association, the recommended pattern is to name the hasOne/hasMany association after the collection or a meaningful label — for example:


```
// In IssuersTable::initialize()
$this->hasOne('Logo', [
    'className' => 'FileStorage.FileStorage',
    'foreignKey' => 'foreign_key',
    'conditions' => [
        'Logo.model'      => 'Issuers',
        'Logo.collection' => 'Logo',
    ],
    'cascadeCallbacks' => true,
    'dependent'        => true,
]);
```
The corresponding variant configuration is naturally written as:

```
Configure::write('FileStorage.imageVariants', [
    'Issuers' => [
        'Logo' => $collection->toArray(),
    ],
]);
```
However, image variants are never created in this setup. No variant file is written to storage, and the variants column in file_storage remains null.

**Root cause**
FileStorageBehavior::processImages() resolves the model key using the table alias of the currently active FileStorageTable instance:


// Before (line 385)
`$model = $this->table()->getAlias();`

When CakePHP saves data through the Logo association, it creates a FileStorageTable instance with alias Logo (the association name). As a result, processImages looks for $imageSizes['Logo']['Logo'], while the configuration defines $imageSizes['Issuers']['Logo'] — the lookup fails silently and the method returns the file unchanged, skipping all variant processing.

**Fix**
Use the model field from the entity instead of the table alias. This field is explicitly set by the application (e.g. in beforeMarshal) to indicate the owning model — exactly the value the configuration is keyed by:


// After
`$model = (string)$entity->get('model');`
This makes processImages resolve $imageSizes['Issuers']['Logo'] correctly regardless of how the association is named, which aligns with the semantics of the model field and with the documentation's recommended setup.