### PR TITLE
Fix PHPStan on CakePHP 5.4

### DIFF
--- a/src/View/Helper/ImageHelper.php
+++ b/src/View/Helper/ImageHelper.php
@@ -24,7 +24,7 @@ class ImageHelper extends Helper
     /**
      * Helpers
      *
-     * @var array<mixed>
+     * @var array<int|string, array<string, mixed>|string>
      */
     protected array $helpers = [
         'Html',


### PR DESCRIPTION
Updates helper/component annotations for CakePHP 5.4/PHPStan covariance checks.\n\nVerified locally with CakePHP 5.4.0-RC2:\n- composer stan\n- composer cs-check\n- composer test